### PR TITLE
feat: all blocks

### DIFF
--- a/core/modules/Block/Controller/Block.php
+++ b/core/modules/Block/Controller/Block.php
@@ -107,6 +107,7 @@ class Block extends \Soosyze\Controller
 
         $values[ 'key_block' ] = $key;
         $values[ 'section' ]   = $body[ 'section' ] ?? null;
+        $values[ 'theme' ]     = $theme;
 
         if (empty($values[ 'hook' ])) {
             $srcImage = self::core()->getPath('modules', 'modules/core', false) . '/Block/Assets/misc/static.svg';
@@ -454,6 +455,7 @@ class Block extends \Soosyze\Controller
             'pages'            => '!required|string',
             'roles'            => '!required|array',
             'section'          => 'required|inarray:' . implode(',', $section),
+            'theme'            => 'required|inarray:public,admin',
             'title'            => 'required|string|max:255',
             'visibility_pages' => 'bool',
             'visibility_roles' => 'bool',
@@ -476,6 +478,7 @@ class Block extends \Soosyze\Controller
                     'pages'     => t('List of pages'),
                     'roles'     => t('User Roles'),
                     'section'   => t('Section'),
+                    'theme'     => t('Theme'),
                     'title'     => t('Title'),
                     'weight'    => t('Weight')
                 ])
@@ -532,6 +535,7 @@ class Block extends \Soosyze\Controller
             'pages'            => $validator->getInput('pages'),
             'roles'            => implode(',', array_keys($validator->getInput('roles', []))),
             'section'          => $validator->getInput('section'),
+            'theme'            => $validator->getInput('theme'),
             'title'            => $validator->getInput('title'),
             'visibility_pages' => (bool) $validator->getInput('visibility_pages'),
             'visibility_roles' => (bool) $validator->getInput('visibility_roles'),

--- a/core/modules/Block/Extend.php
+++ b/core/modules/Block/Extend.php
@@ -34,11 +34,12 @@ class Extend extends \SoosyzeCore\System\ExtendModule
                 ->text('hook')->nullable()
                 ->integer('weight')
                 ->boolean('visibility_pages')->valueDefault(false)
-                ->string('pages')->valueDefault('admin/%' . PHP_EOL . 'user/%')
+                ->string('pages')->valueDefault('user/%')
                 ->boolean('visibility_roles')->valueDefault(true)
                 ->string('roles')->valueDefault('1,2')
                 ->string('key_block')->nullable()
-                ->text('options')->nullable();
+                ->text('options')->nullable()
+                ->text('theme')->valueDefault('public');
             });
 
         $ci->config()->set('settings.icon_socials', [
@@ -65,12 +66,12 @@ class Extend extends \SoosyzeCore\System\ExtendModule
         $ci->query()
             ->insertInto('block', [
                 'section', 'title', 'is_title',
-                'weight', 'visibility_pages', 'pages',
+                'weight', 'pages', 'theme',
                 'content'
             ])
             ->values([
                 'content_footer', t('Found an bug'), false,
-                50, true, 'admin/%',
+                50, '', 'admin',
                 '<div class="block-report_github">'
                 . '<p>'
                 . '<a href="https://github.com/soosyze/soosyze/issues" '
@@ -85,7 +86,7 @@ class Extend extends \SoosyzeCore\System\ExtendModule
             ])
             ->values([
                 'footer', t('Power by'), false,
-                50, false, '',
+                50, '', 'public',
                 '<p>Power by <a href="https://soosyze.com">SoosyzeCMS</a></p>',
             ])
             ->execute();

--- a/core/modules/Block/Form/FormBlock.php
+++ b/core/modules/Block/Form/FormBlock.php
@@ -23,9 +23,10 @@ class FormBlock extends \Soosyze\Components\Form\FormBuilder
         'content'          => '',
         'is_title'         => true,
         'key_block'        => '',
-        'pages'            => 'admin/%' . PHP_EOL . 'user/%',
+        'pages'            => 'user/%',
         'roles'            => [ 1, 2 ],
         'section'          => '',
+        'theme'            => 'public',
         'title'            => '',
         'visibility_pages' => false,
         'visibility_roles' => true,
@@ -193,6 +194,7 @@ class FormBlock extends \Soosyze\Components\Form\FormBuilder
             ->group('submit-group', 'div', function ($form) {
                 $form->token($this->getTokenName())
                 ->hidden('key_block', [ 'value' => $this->values[ 'key_block' ] ])
+                ->hidden('theme', [ 'value' => $this->values[ 'theme' ] ])
                 ->hidden('section', [ 'value' => $this->values[ 'section' ] ])
                 ->hidden('weight', [ 'value' => $this->values[ 'weight' ] ])
                 ->submit('submit', t('Save'), [ 'class' => 'btn btn-success' ]);

--- a/core/modules/Block/Migrations/2021_10_02_000000_add_theme_name.php
+++ b/core/modules/Block/Migrations/2021_10_02_000000_add_theme_name.php
@@ -1,0 +1,26 @@
+<?php
+
+use Queryflatfile\Request;
+use Queryflatfile\Schema;
+use Queryflatfile\TableAlter;
+
+return [
+    'up' => function (Schema $sch, Request $req) {
+        $sch->alterTable('block', function (TableAlter $table) {
+            $table->text('theme')->valueDefault('public');
+        });
+
+        $req->update('block', [ 'theme' => 'admin' ])
+            ->where('block_id', '=', 1)
+            ->execute();
+
+        $blocks = $req->from('block')->fetchAll();
+        foreach ($blocks as $block) {
+            $req->update('block', [
+                    'pages' => str_replace('admin/%' . PHP_EOL, '', $block[ 'pages' ])
+                ])
+                ->where('block_id', '=', $block[ 'block_id' ])
+                ->execute();
+        }
+    }
+];

--- a/core/modules/Block/Views/section.php
+++ b/core/modules/Block/Views/section.php
@@ -51,10 +51,12 @@
 
         </div>
     <?php endforeach; ?>
-
-    <?php if ($is_admin) : ?>
+    <?php if ($is_admin): ?>
 
     </div>
+    <?php endif; ?>
+    <?php if ($link_create): ?>
+
     <div class="block-actions">
         <a data-target="#modal_block"
            data-toogle="modal"

--- a/core/modules/Menu/Config/services.php
+++ b/core/modules/Menu/Config/services.php
@@ -7,6 +7,7 @@ return [
     'menu.extend' => [
         'class' => 'SoosyzeCore\Menu\Extend',
         'hooks' => [
+            'install.block' => 'hookInstallBlock',
             'install.user' => 'hookInstallUser'
         ]
     ],
@@ -36,7 +37,6 @@ return [
     'menu.hook.app' => [
         'class' => 'SoosyzeCore\Menu\Hook\App',
         'hooks' => [
-            'app.response.after' => 'hookResponseAfter',
             'menu.admin.response.after' => 'hookMenuShowResponseAfter',
             'menu.show.response.after' => 'hookMenuShowResponseAfter'
         ]

--- a/core/modules/Menu/Extend.php
+++ b/core/modules/Menu/Extend.php
@@ -80,9 +80,48 @@ class Extend extends \SoosyzeCore\System\ExtendModule
 
     public function hookInstall(ContainerInterface $ci): void
     {
+        if ($ci->module()->has('Block')) {
+            $this->hookInstallBlock($ci);
+        }
         if ($ci->module()->has('User')) {
             $this->hookInstallUser($ci);
         }
+    }
+
+    public function hookInstallBlock(ContainerInterface $ci): void
+    {
+        $ci->query()
+            ->insertInto('block', [
+                'title', 'is_title', 'section', 'hook',
+                'weight', 'pages', 'key_block',
+                'options',
+                'theme'
+            ])
+            ->values([
+                'Administration menu', false, 'main_menu', 'menu',
+                0, '', 'menu',
+                json_encode([ 'depth' => 10, 'name' => 'menu-admin', 'parent' => -1 ]),
+                'admin'
+            ])
+            ->values([
+                'User Menu', false, 'second_menu', 'menu',
+                1, '', 'menu',
+                json_encode([ 'depth' => 10, 'name' => 'menu-user', 'parent' => -1 ]),
+                'admin'
+            ])
+            ->values([
+                'Main Menu', false, 'main_menu', 'menu',
+                0, '', 'menu',
+                json_encode([ 'depth' => 10, 'name' => 'menu-main', 'parent' => -1 ]),
+                'public'
+            ])
+            ->values([
+                'User Menu', false, 'second_menu', 'menu',
+                1, '', 'menu',
+                json_encode([ 'depth' => 10, 'name' => 'menu-user', 'parent' => -1 ]),
+                'public'
+            ])
+            ->execute();
     }
 
     public function hookInstallUser(ContainerInterface $ci): void

--- a/core/modules/Menu/Hook/App.php
+++ b/core/modules/Menu/Hook/App.php
@@ -17,29 +17,9 @@ class App
      */
     private $core;
 
-    /**
-     * @var Menu
-     */
-    private $menu;
-
-    public function __construct(Core $core, Menu $menu)
+    public function __construct(Core $core)
     {
         $this->core = $core;
-        $this->menu = $menu;
-    }
-
-    public function hookResponseAfter(RequestInterface $request, ResponseInterface &$response): void
-    {
-        if (!($response instanceof Templating)) {
-            return;
-        }
-        $nameMenu = $response->isTheme('theme')
-            ? 'menu-main'
-            : 'menu-admin';
-
-        $response
-            ->addBlock('page.main_menu', $this->menu->renderMenu($nameMenu))
-            ->addBlock('page.second_menu', $this->menu->renderMenu('menu-user'));
     }
 
     public function hookMenuShowResponseAfter(RequestInterface $request, ResponseInterface &$response): void

--- a/core/modules/Menu/Migrations/2021_10_03_000000_insert_menu_block.php
+++ b/core/modules/Menu/Migrations/2021_10_03_000000_insert_menu_block.php
@@ -1,0 +1,48 @@
+<?php
+
+use Queryflatfile\Request;
+use Queryflatfile\Schema;
+
+return [
+    'up' => function (Schema $sch, Request $req) {
+        if (!$sch->hasTable('block')) {
+            return;
+        }
+
+        $req
+            ->insertInto('block', [
+                'title', 'is_title', 'section', 'hook',
+                'weight', 'pages', 'key_block',
+                'options',
+                'theme'
+            ])
+            ->values([
+                t('Administration menu'), false, 'main_menu', 'menu',
+                0, '', 'menu',
+                json_encode([ 'depth' => 10, 'name' => 'menu-admin', 'parent' => -1 ]),
+                'admin'
+            ])
+            ->values([
+                t('User Menu'), false, 'second_menu', 'menu',
+                1, '', 'menu',
+                json_encode([ 'depth' => 10, 'name' => 'menu-user', 'parent' => -1 ]),
+                'admin'
+            ])
+            ->values([
+                t('Main Menu'), false, 'main_menu', 'menu',
+                0, '', 'menu',
+                json_encode([ 'depth' => 10, 'name' => 'menu-main', 'parent' => -1 ]),
+                'public'
+            ])
+            ->values([
+                t('User Menu'), false, 'second_menu', 'menu',
+                1, '', 'menu',
+                json_encode([ 'depth' => 10, 'name' => 'menu-user', 'parent' => -1 ]),
+                'public'
+            ])
+            ->execute();
+
+        $req->insertInto('module_require', [ 'title_module', 'title_required', 'version' ])
+            ->values('Menu', 'Block', '1.0.*');
+    }
+];

--- a/core/modules/Menu/composer.json
+++ b/core/modules/Menu/composer.json
@@ -13,6 +13,9 @@
             "title": "Menu",
             "package": "Core",
             "controller": "SoosyzeCore\\Menu\\Controller\\Menu",
+            "require": {
+                "Block": "1.0.*"
+            },
             "icon": {
                 "name": "fas fa-bars",
                 "background-color": "#2454a8",

--- a/core/modules/System/Hook/Step.php
+++ b/core/modules/System/Hook/Step.php
@@ -537,7 +537,7 @@ class Step
                 1,
                 'social', 'social',
                 null,
-                false, '/' . PHP_EOL . 'admin/%' . PHP_EOL . 'user/%'
+                false, '/' . PHP_EOL . 'user/%'
             ])
             ->values([
                 'sidebar', t('Archives list'), true,
@@ -609,14 +609,14 @@ class Step
                 1,
                 'news.archive', 'news.archive',
                 json_encode([ 'expand' => false ]),
-                false, 'admin/%' . PHP_EOL . 'user/%'
+                false, 'user/%'
             ])
             ->values([
                 'footer_first', t('Follow us'), true,
                 1,
                 'social', 'social',
                 null,
-                false, 'admin/%' . PHP_EOL . 'user/%'
+                false, 'user/%'
             ])
             ->execute();
 
@@ -857,7 +857,7 @@ class Step
             ->values([
                 'footer_first', 'Lorem ipsum', true,
                 1,
-                false, 'admin/%' . PHP_EOL . 'user/%',
+                false, 'user/%',
                 (new Template('block-text.php', $this->pathContent))->render()
             ])
             ->execute();

--- a/core/themes/Admin/composer.json
+++ b/core/themes/Admin/composer.json
@@ -12,11 +12,11 @@
         "soosyze": {
             "title": "Admin",
             "sections": [
-                "header",
-                "sidebar",
                 "content_header",
                 "content_footer",
-                "footer"
+                "footer",
+                "main_menu",
+                "second_menu"
             ],
             "options": {
                 "dark": true,

--- a/core/themes/Admin/page.php
+++ b/core/themes/Admin/page.php
@@ -34,7 +34,6 @@
                         </ul>
 
                         <?php echo $section[ 'main_menu' ]; ?>
-                        <?php echo $section[ 'second_menu' ]; ?>
                     </div>
                 </div>
             </div>
@@ -60,12 +59,7 @@
                     </ul>
                     <?php echo $section[ 'main_menu' ]; ?>
 
-                    <?php if (!empty($section[ 'sidebar' ])): ?>
-                        <?php echo $section[ 'sidebar' ]; ?>
-
-                    <?php endif; ?>
                     <?php echo $section[ 'second_menu' ]; ?>
-
                 </div>
             </div>
         </div>

--- a/core/themes/Bootstrap3/composer.json
+++ b/core/themes/Bootstrap3/composer.json
@@ -18,7 +18,9 @@
                 "content_footer",
                 "footer",
                 "footer_column_first",
-                "footer_column_second"
+                "footer_column_second",
+                "main_menu",
+                "second_menu"
             ]
         }
     }

--- a/core/themes/Fez/composer.json
+++ b/core/themes/Fez/composer.json
@@ -18,7 +18,9 @@
                 "content_footer",
                 "footer",
                 "footer_first",
-                "footer_second"
+                "footer_second",
+                "main_menu",
+                "second_menu"
             ]
         }
     }

--- a/core/themes/Fez/page.php
+++ b/core/themes/Fez/page.php
@@ -124,8 +124,9 @@
                     <?php echo $section[ 'footer' ]; ?>
                 <?php endif; ?>
 
+                <div class="menu_user">
                 <?php echo $section[ 'second_menu' ]; ?>
-
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Tous les éléments de la page en dehors du contenu principale doit être contenus dans des blocs.

Les menus injectés directement dans les thèmes passeront par le module blocks. Ce changement permet d'utiliser pleinement les options de personnalisation des blocs. Le module blocs est donc requis par le module menu.

La section main_menu ne pourra posséder qu'un bloc et proposera d'en ajouter un s'il n'en contient pas.

La gestion des blocs du thème public et d'administration seront séparés. Les bloc créés sur le thème public seront affichés uniquement sur le thème public et les blocs créés sur le thème d'administration seront affichés uniquement sur le thème d'administration.