### PR TITLE
chore: new format for route parameters

### DIFF
--- a/core/modules/BackupManager/Config/routes.php
+++ b/core/modules/BackupManager/Config/routes.php
@@ -8,8 +8,8 @@ define('FILE_PATTERN', '2[\d]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][\d]|3[01])T([01][\
 RouteCollection::setNamespace('SoosyzeCore\BackupManager\Controller\BackupController')->name('backupmanager.')->prefix('/admin/tool/backupmanager')->group(function (RouteGroup $r): void {
     $r->get('admin', '/', '@admin');
     $r->get('dobackup', '/do', '@doBackup');
-    $r->get('download', '/download/:file', '@download', [ ':file' => FILE_PATTERN ]);
-    $r->get('restore', '/restore/:file', '@restore', [ ':file' => FILE_PATTERN ]);
-    $r->get('delete', '/delete/:file', '@delete', [ ':file' => FILE_PATTERN ]);
+    $r->get('download', '/download/{file}', '@download', [ 'file' => FILE_PATTERN ]);
+    $r->get('restore', '/restore/{file}', '@restore', [ 'file' => FILE_PATTERN ]);
+    $r->get('delete', '/delete/{file}', '@delete', [ 'file' => FILE_PATTERN ]);
     $r->get('delete.all', '/delete/all', '@deleteAll');
 });

--- a/core/modules/BackupManager/Services/BackupManager.php
+++ b/core/modules/BackupManager/Services/BackupManager.php
@@ -73,13 +73,13 @@ class BackupManager
                 'date'          => \date_create_from_format(self::DATE_FORMAT, str_replace('soosyzecms.zip', '', $file->getFilename())),
                 'size'          => $file->getSize(),
                 'download_link' => $this->router->generateUrl('backupmanager.download', [
-                    ':file' => strtr($file->getFilename(), [ self::SUFFIX => '' ])
+                    'file' => strtr($file->getFilename(), [ self::SUFFIX => '' ])
                 ]),
                 'restore_link'  => $this->router->generateUrl('backupmanager.restore', [
-                    ':file' => strtr($file->getFilename(), [ self::SUFFIX => '' ])
+                    'file' => strtr($file->getFilename(), [ self::SUFFIX => '' ])
                 ]),
                 'delete_link'   => $this->router->generateUrl('backupmanager.delete', [
-                    ':file' => strtr($file->getFilename(), [ self::SUFFIX => '' ])
+                    'file' => strtr($file->getFilename(), [ self::SUFFIX => '' ])
                 ])
             ];
         }

--- a/core/modules/Block/Config/routes.php
+++ b/core/modules/Block/Config/routes.php
@@ -4,23 +4,23 @@ use Soosyze\Components\Router\RouteCollection;
 use Soosyze\Components\Router\RouteGroup;
 
 define('BLOCK_WITHS_THEME', [
-    ':theme' => 'public|admin'
+    'theme' => 'public|admin'
 ]);
 
 RouteCollection::setNamespace('SoosyzeCore\Block\Controller')->name('block.')->group(function (RouteGroup $r): void {
     $r->setNamespace('\Section')->name('section.')->prefix('/admin')->withs(BLOCK_WITHS_THEME)->group(function (RouteGroup $r): void {
-        $r->get('admin', '/theme/:theme/section', '@admin');
-        $r->post('update', '/section/:id/edit', '@update')->whereDigits(':id');
+        $r->get('admin', '/theme/{theme}/section', '@admin');
+        $r->post('update', '/section/{id}/edit', '@update')->whereDigits('id');
     });
     $r->setNamespace('\Block')->prefix('/block')->withs(BLOCK_WITHS_THEME)->group(function (RouteGroup $r): void {
-        $r->get('create.list', '/:theme/create/:section', '@createList')->whereWords(':section');
-        $r->get('create.show', '/create/:id', '@createShow', [ ':id' => '[\w\.\-]+' ]);
-        $r->post('create.form', '/:theme/create/form', '@createForm');
+        $r->get('create.list', '/{theme}/create/{section}', '@createList')->whereWords('section');
+        $r->get('create.show', '/create/{id}', '@createShow', [ 'id' => '[\w\.\-]+' ]);
+        $r->post('create.form', '/{theme}/create/form', '@createForm');
 
-        $r->post('store', '/:theme', '@store');
-        $r->get('edit', '/:theme/:id/edit', '@edit')->whereDigits(':id');
-        $r->put('update', '/:theme/:id', '@update')->whereDigits(':id');
-        $r->get('remove', '/:theme/:id/delete', '@remove')->whereDigits(':id');
-        $r->delete('delete', '/:theme/:id', '@delete')->whereDigits(':id');
+        $r->post('store', '/{theme}', '@store');
+        $r->get('edit', '/{theme}/{id}/edit', '@edit')->whereDigits('id');
+        $r->put('update', '/{theme}/{id}', '@update')->whereDigits('id');
+        $r->get('remove', '/{theme}/{id}/delete', '@remove')->whereDigits('id');
+        $r->delete('delete', '/{theme}/{id}', '@delete')->whereDigits('id');
     });
 });

--- a/core/modules/Block/Controller/Block.php
+++ b/core/modules/Block/Controller/Block.php
@@ -36,12 +36,13 @@ class Block extends \Soosyze\Controller
 
         foreach ($blocks as $key => &$block) {
             $block[ 'link_show_create' ] = self::router()->generateUrl('block.create.show', [
-                ':id' => $key
+                'theme' => $theme,
+                'id'    => $key
             ]);
         }
 
         $action = self::router()->generateUrl('block.create.form', [
-            ':theme'   => $theme
+            'theme'   => $theme
         ]);
 
         $form = (new FormListBlock([ 'action' => $action, 'method' => 'post' ]))
@@ -66,9 +67,9 @@ class Block extends \Soosyze\Controller
     /**
      * @return ServiceBlock|ResponseInterface
      */
-    public function createShow(string $name)
+    public function createShow(string $id)
     {
-        $block = self::block()->getBlock($name);
+        $block = self::block()->getBlock($id);
 
         if (!$block) {
             return $this->get404();
@@ -130,7 +131,7 @@ class Block extends \Soosyze\Controller
         $this->container->callHook('block.create.form.data', [ &$values, $theme ]);
 
         $action = self::router()->generateUrl('block.store', [
-            ':theme'   => $theme
+            'theme'   => $theme
         ]);
 
         $form = (new FormBlock([
@@ -226,7 +227,7 @@ class Block extends \Soosyze\Controller
 
             return $this->json(201, [
                     'redirect' => self::router()->generateUrl('block.section.admin', [
-                        ':theme'   => $theme
+                        'theme'   => $theme
                     ])
             ]);
         }
@@ -261,8 +262,8 @@ class Block extends \Soosyze\Controller
         $this->container->callHook('block.edit.form.data', [ &$values, $theme, $id ]);
 
         $action = self::router()->generateUrl('block.update', [
-            ':theme'   => $theme,
-            ':id'      => $values[ 'block_id' ]
+            'theme'   => $theme,
+            'id'      => $values[ 'block_id' ]
         ]);
 
         $form = (new FormBlock([
@@ -353,7 +354,7 @@ class Block extends \Soosyze\Controller
 
             return $this->json(200, [
                     'redirect'    => self::router()->generateUrl('block.section.admin', [
-                        ':theme'   => $theme
+                        'theme'   => $theme
                     ])
             ]);
         }
@@ -379,8 +380,8 @@ class Block extends \Soosyze\Controller
         $this->container->callHook('block.remove.form.data', [ &$values, $theme, $id ]);
 
         $action = self::router()->generateUrl('block.delete', [
-            ':theme'   => $theme,
-            ':id'      => $values[ 'block_id' ]
+            'theme'   => $theme,
+            'id'      => $values[ 'block_id' ]
         ]);
 
         $form = (new FormDeleteBlock([
@@ -427,7 +428,7 @@ class Block extends \Soosyze\Controller
 
             return $this->json(200, [
                     'redirect' => self::router()->generateUrl('block.section.admin', [
-                        ':theme' => $theme
+                        'theme' => $theme
                     ])
             ]);
         }

--- a/core/modules/Block/Controller/Section.php
+++ b/core/modules/Block/Controller/Section.php
@@ -43,7 +43,7 @@ class Section extends \Soosyze\Controller
                         : 'Edit admin theme blocks',
                     'link_theme_index' => self::router()->generateUrl('system.theme.index'),
                     'link_section'     => self::router()->generateUrl('block.section.admin', [
-                        ':theme' => $theme === 'admin'
+                        'theme' => $theme === 'admin'
                         ? 'public'
                         : 'admin'
                     ])

--- a/core/modules/Block/Hook/App.php
+++ b/core/modules/Block/Hook/App.php
@@ -99,8 +99,8 @@ class App
                 'is_admin'    => $isAdmin,
                 'link_create' => ($isAdmin && ($section !== 'main_menu' || ($section === 'main_menu' && empty($blocks['main_menu']))))
                     ? $this->router->generateUrl('block.create.list', [
-                        ':theme'   => $theme,
-                        ':section' => $section
+                        'theme'   => $theme,
+                        'section' => $section
                     ])
                     : null
             ]);
@@ -110,8 +110,8 @@ class App
     private function isAdmin(): bool
     {
         return in_array($this->router->getPathFromRequest(), [
-                'admin/theme/public/section',
-                'admin/theme/admin/section'
+                '/admin/theme/public/section',
+                '/admin/theme/admin/section'
             ]) && $this->core->callHook('app.granted', [ 'block.administer' ]);
     }
 
@@ -159,8 +159,8 @@ class App
             }
             if ($isAdmin) {
                 $params = [
-                    ':theme' => $theme,
-                    ':id'    => $block[ 'block_id' ]
+                    'theme' => $theme,
+                    'id'    => $block[ 'block_id' ]
                 ];
 
                 $block[ 'link_edit' ]   = $this->router->generateUrl('block.edit', $params);

--- a/core/modules/Block/Hook/Block.php
+++ b/core/modules/Block/Hook/Block.php
@@ -195,7 +195,7 @@ class Block implements \SoosyzeCore\Block\BlockInterface
                     $form->html('code_integration-label', '<a:attr>:content</a>', [
                         ':content' => t('Configure the list of your social networks from the configuration interface of your site'),
                         'href'     => $this->router->generateUrl('config.edit', [
-                            ':id' => 'social'
+                            'id' => 'social'
                         ]),
                         'target'   => '_blank'
                     ]);

--- a/core/modules/Block/Services/Block.php
+++ b/core/modules/Block/Services/Block.php
@@ -87,8 +87,8 @@ class Block
                 'icon'       => 'fa fa-edit',
                 'key'        => 'block.edit',
                 'link'       => $this->router->generateUrl('block.edit', [
-                    ':theme'   => $theme,
-                    ':id'      => $id
+                    'theme'   => $theme,
+                    'id'      => $id
                 ]),
                 'title_link' => t('Edit')
             ], [
@@ -96,8 +96,8 @@ class Block
                 'icon'       => 'fa fa-times',
                 'key'        => 'block.remove',
                 'link'       => $this->router->generateUrl('block.remove', [
-                    ':theme'   => $theme,
-                    ':id'      => $id
+                    'theme'   => $theme,
+                    'id'      => $id
                 ]),
                 'title_link' => t('Delete')
             ]

--- a/core/modules/Config/Config/routes.php
+++ b/core/modules/Config/Config/routes.php
@@ -5,6 +5,6 @@ use Soosyze\Components\Router\RouteGroup;
 
 RouteCollection::setNamespace('SoosyzeCore\Config\Controller\Config')->name('config.')->prefix('/admin/config')->group(function (RouteGroup $r): void {
     $r->get('admin', '/', '@admin');
-    $r->get('edit', '/:id', '@edit')->whereWords(':id');
-    $r->put('update', '/:id', '@update')->whereWords(':id');
+    $r->get('edit', '/{id}', '@edit')->whereWords('id');
+    $r->put('update', '/{id}', '@update')->whereWords('id');
 });

--- a/core/modules/Config/Controller/Config.php
+++ b/core/modules/Config/Controller/Config.php
@@ -101,7 +101,7 @@ class Config extends \Soosyze\Controller
             $_SESSION[ 'messages' ][ 'success' ][] = t('Saved configuration');
 
             return $this->json(200, [
-                    'redirect' => self::router()->generateUrl('config.edit', [ ':id' => $id ])
+                    'redirect' => self::router()->generateUrl('config.edit', [ 'id' => $id ])
             ]);
         }
 
@@ -131,7 +131,7 @@ class Config extends \Soosyze\Controller
         $this->container->callHook("config.edit.$id.form.data", [ &$data, $id ]);
 
         $form = new FormBuilder([
-            'action'  => self::router()->generateUrl('config.update', [ ':id' => $id ]),
+            'action'  => self::router()->generateUrl('config.update', [ 'id' => $id ]),
             'class'   => 'form-api',
             'enctype' => 'multipart/form-data',
             'method'  => 'put'
@@ -173,7 +173,7 @@ class Config extends \Soosyze\Controller
         $all = $this->container->callHook('app.granted', [ 'config.manage' ]);
         foreach ($menu as $key => &$link) {
             if ($all || $this->container->callHook('app.granted', [ $key . '.config.manage' ])) {
-                $link[ 'link' ] = self::router()->generateUrl('config.edit', [ ':id' => $key ]);
+                $link[ 'link' ] = self::router()->generateUrl('config.edit', [ 'id' => $key ]);
 
                 continue;
             }

--- a/core/modules/FileManager/Config/routes.php
+++ b/core/modules/FileManager/Config/routes.php
@@ -4,30 +4,30 @@ use Soosyze\Components\Router\RouteCollection;
 use Soosyze\Components\Router\RouteGroup;
 
 define('FILEMANAGER_FILE_WITH', [
-    ':path' => '(/[-\w]+){0,255}',
-    ':name' => '/[-\w ]{1,255}',
-    ':ext'  => '\.[a-zA-Z0-9]{1,10}'
+    'path' => '(/[-\w]+){0,255}',
+    'name' => '/[-\w ]{1,255}',
+    'ext'  => '\.[a-zA-Z0-9]{1,10}'
 ]);
-define('FILEMANAGER_PATH_WITH', [ ':path' => '(/[-\w]+){0,255}' ]);
+define('FILEMANAGER_PATH_WITH', [ 'path' => '(/[-\w]+){0,255}' ]);
 
 RouteCollection::setNamespace('SoosyzeCore\FileManager\Controller')->prefix('/filemanager')->name('filemanager.')->group(function (RouteGroup $r): void {
     $r->prefix('/file')->name('file.')->setNamespace('\File')->group(function (RouteGroup $r): void {
-        $r->get('show', ':path:name:ext', '@show', FILEMANAGER_FILE_WITH);
-        $r->get('create', ':path', '@create', FILEMANAGER_PATH_WITH);
-        $r->post('store', ':path', '@store', FILEMANAGER_PATH_WITH);
-        $r->get('edit', ':path:name:ext/edit', '@edit', FILEMANAGER_FILE_WITH);
-        $r->put('update', ':path:name:ext', '@update', FILEMANAGER_FILE_WITH);
-        $r->get('remove', ':path:name:ext/delete', '@remove', FILEMANAGER_FILE_WITH);
-        $r->delete('delete', ':path:name:ext', '@delete', FILEMANAGER_FILE_WITH);
-        $r->get('download', ':path:name:ext/download', '@download', FILEMANAGER_FILE_WITH);
+        $r->get('show', '{path}{name}{ext}', '@show', FILEMANAGER_FILE_WITH);
+        $r->get('create', 'path', '@create', FILEMANAGER_PATH_WITH);
+        $r->post('store', 'path', '@store', FILEMANAGER_PATH_WITH);
+        $r->get('edit', '{path}{name}{ext}/edit', '@edit', FILEMANAGER_FILE_WITH);
+        $r->put('update', '{path}{name}{ext}', '@update', FILEMANAGER_FILE_WITH);
+        $r->get('remove', '{path}{name}{ext}/delete', '@remove', FILEMANAGER_FILE_WITH);
+        $r->delete('delete', '{path}{name}{ext}', '@delete', FILEMANAGER_FILE_WITH);
+        $r->get('download', '{path}{name}{ext}/download', '@download', FILEMANAGER_FILE_WITH);
     });
     /* Affichage du filemanager uniquement les répertoires. */
     $r->prefix('/copy')->name('copy.')->setNamespace('\FileCopy')->group(function (RouteGroup $r): void {
-        $r->get('admin', ':path:name:ext', '@admin', FILEMANAGER_FILE_WITH);
-        $r->post('update', ':path:name:ext', 'y@update', FILEMANAGER_FILE_WITH);
-        $r->get('show', ':path', '@show', FILEMANAGER_PATH_WITH);
+        $r->get('admin', '{path}{name}{ext}', '@admin', FILEMANAGER_FILE_WITH);
+        $r->post('update', '{path}{name}{ext}', '@update', FILEMANAGER_FILE_WITH);
+        $r->get('show', 'path', '@show', FILEMANAGER_PATH_WITH);
     });
-    $r->prefix('/folder:path')->withs([':path' => '(/[-\w]+){1,255}' ])->name('folder.')->setNamespace('\Folder')->group(function (RouteGroup $r): void {
+    $r->prefix('/folder{path}')->withs(['path' => '(/[-\w]+){1,255}' ])->name('folder.')->setNamespace('\Folder')->group(function (RouteGroup $r): void {
         $r->get('create', '/create', '@create', FILEMANAGER_PATH_WITH);
         $r->post('store', '/', '@store', FILEMANAGER_PATH_WITH);
         $r->get('edit', '/edit', '@edit');
@@ -41,9 +41,9 @@ RouteCollection::prefix('/admin')->name('filemanager.')->setNamespace('SoosyzeCo
     /* Affichage du filemanager complet. */
     $r->prefix('/filemanager')->setNamespace('\Manager')->group(function (RouteGroup $r): void {
         $r->get('admin', '/show', '@admin');
-        $r->get('public', '/public:path', '@showPublic', FILEMANAGER_PATH_WITH);
-        $r->get('show', '/show:path', '@show', FILEMANAGER_PATH_WITH);
-        $r->get('filter', '/filter:path', '@filter', FILEMANAGER_PATH_WITH);
+        $r->get('public', '/public{path}', '@showPublic', FILEMANAGER_PATH_WITH);
+        $r->get('show', '/show{path}', '@show', FILEMANAGER_PATH_WITH);
+        $r->get('filter', '/filter{path}', '@filter', FILEMANAGER_PATH_WITH);
     });
     $r->prefix('/user/permission/filemanager')->name('permission.')->group(function (RouteGroup $r): void {
         $r->setNamespace('\FilePermissionManager')->group(function (RouteGroup $r): void {
@@ -53,10 +53,10 @@ RouteCollection::prefix('/admin')->name('filemanager.')->setNamespace('SoosyzeCo
         $r->setNamespace('\FilePermission')->group(function (RouteGroup $r): void {
             $r->get('create', '/create', '@create');
             $r->post('store', '/', '@store');
-            $r->get('edit', '/:id/edit', '@edit')->whereDigits(':id');
-            $r->put('update', '/:id', '@update')->whereDigits(':id');
-            $r->get('remove', '/:id/delete', '@remove')->whereDigits(':id');
-            $r->delete('delete', '/:id', '@delete')->whereDigits(':id');
+            $r->get('edit', '/{id}/edit', '@edit')->whereDigits('id');
+            $r->put('update', '/{id}', '@update')->whereDigits('id');
+            $r->get('remove', '/{id}/delete', '@remove')->whereDigits('id');
+            $r->delete('delete', '/{id}', '@delete')->whereDigits('id');
         });
     });
 });

--- a/core/modules/FileManager/Controller/File.php
+++ b/core/modules/FileManager/Controller/File.php
@@ -94,7 +94,7 @@ class File extends \Soosyze\Controller
 
         $form = (new FormBuilder([
                 'action'  => self::router()->generateUrl('filemanager.file.store', [
-                    ':path' => $path
+                    'path' => $path
                 ]),
                 'class'   => 'filemanager-dropfile',
                 'method'  => 'post',
@@ -256,7 +256,7 @@ class File extends \Soosyze\Controller
         $data = self::filemanager()->parseFile($spl, $path);
 
         $action = self::router()->generateUrl('filemanager.file.update', [
-            ':path' => $path, ':name' => $name, ':ext'  => $ext
+            'path' => $path, 'name' => $name, 'ext'  => $ext
         ]);
 
         $form = (new FormBuilder([ 'action' => $action, 'method' => 'put']))
@@ -346,7 +346,7 @@ class File extends \Soosyze\Controller
         }
 
         $action = self::router()->generateUrl('filemanager.file.delete', [
-            ':path' => $path, ':name' => $name, ':ext'  => $ext
+            'path' => $path, 'name' => $name, 'ext'  => $ext
         ]);
 
         $form = (new FormBuilder([ 'action' => $action, 'method' => 'delete' ]))

--- a/core/modules/FileManager/Controller/FileCopy.php
+++ b/core/modules/FileManager/Controller/FileCopy.php
@@ -40,7 +40,7 @@ class FileCopy extends \Soosyze\Controller
         }
 
         $action = self::router()->generateUrl('filemanager.copy.update', [
-            ':path' => $path, ':name' => $name, ':ext'  => $ext
+            'path' => $path, 'name' => $name, 'ext'  => $ext
         ]);
 
         $form = (new FormBuilder([ 'action' => $action, 'method' => 'post' ]))
@@ -122,7 +122,7 @@ class FileCopy extends \Soosyze\Controller
                 ->addVars([
                     'files'        => $files,
                     'link_show'    => self::router()->generateUrl('filemanager.copy.show', [
-                        ':path' => $path
+                        'path' => $path
                     ]),
                     'path'         => $path,
                     'profil'       => $hookUser->getRight($path),

--- a/core/modules/FileManager/Controller/FilePermission.php
+++ b/core/modules/FileManager/Controller/FilePermission.php
@@ -112,7 +112,7 @@ class FilePermission extends \Soosyze\Controller
 
         $this->container->callHook('filemanager.permission.edit.form.data', [ &$values ]);
 
-        $action = self::router()->generateUrl('filemanager.permission.update', [ ':id' => $id ]);
+        $action = self::router()->generateUrl('filemanager.permission.update', [ 'id' => $id ]);
 
         $form = (new FormPermission([ 'action' => $action, 'method' => 'put' ]))
             ->setRoles(self::query()->from('role')->fetchAll())
@@ -188,7 +188,7 @@ class FilePermission extends \Soosyze\Controller
         }
 
         $action = self::router()->generateUrl('filemanager.permission.delete', [
-            ':id' => $id
+            'id' => $id
         ]);
 
         $form = (new FormBuilder([ 'action' => $action, 'class' => 'form-api', 'method' => 'delete' ]))
@@ -398,13 +398,13 @@ class FilePermission extends \Soosyze\Controller
             [
                 'key'        => 'filemanager.permission.edit',
                 'request'    => self::router()->generateRequest('filemanager.permission.edit', [
-                    ':id' => $idPermission
+                    'id' => $idPermission
                 ]),
                 'title_link' => t('Edit')
             ], [
                 'key'        => 'filemanager.permission.remove',
                 'request'    => self::router()->generateRequest('filemanager.permission.remove', [
-                    ':id' => $idPermission
+                    'id' => $idPermission
                 ]),
                 'title_link' => t('Delete')
             ]

--- a/core/modules/FileManager/Controller/Folder.php
+++ b/core/modules/FileManager/Controller/Folder.php
@@ -39,7 +39,7 @@ class Folder extends \Soosyze\Controller
 
         $values = [];
 
-        $action = self::router()->generateUrl('filemanager.folder.store', [ ':path' => $path ]);
+        $action = self::router()->generateUrl('filemanager.folder.store', [ 'path' => $path ]);
 
         $form = (new FormFolder([ 'action' => $action, 'method' => 'post' ]))
             ->setValues($values)
@@ -104,7 +104,7 @@ class Folder extends \Soosyze\Controller
 
         $values = self::filemanager()->parseDir($spl, $path);
 
-        $action = self::router()->generateUrl('filemanager.folder.update', [ ':path' => $path ]);
+        $action = self::router()->generateUrl('filemanager.folder.update', [ 'path' => $path ]);
 
         $form = (new FormFolder([ 'action' => $action, 'method' => 'put' ]))
             ->setValues($values)
@@ -172,7 +172,7 @@ class Folder extends \Soosyze\Controller
         }
 
         $action = self::router()->generateUrl('filemanager.folder.delete', [
-            ':path' => $path
+            'path' => $path
         ]);
 
         $form = (new FormBuilder([ 'action' => $action, 'method' => 'delete' ]))

--- a/core/modules/FileManager/Controller/Manager.php
+++ b/core/modules/FileManager/Controller/Manager.php
@@ -60,7 +60,7 @@ class Manager extends \Soosyze\Controller
 
         $form = (new FormBuilder([
                 'action' => self::router()->generateUrl('filemanager.filter', [
-                    ':path' => Util::cleanPath('/' . $path)
+                    'path' => Util::cleanPath('/' . $path)
                 ]),
                 'id'     => 'form_filter_file',
                 'method' => 'get'
@@ -177,10 +177,10 @@ class Manager extends \Soosyze\Controller
                 ->addVars([
                     'files'       => $files,
                     'link_search' => self::router()->generateUrl('filemanager.filter', [
-                        ':path' => $path
+                        'path' => $path
                     ]),
                     'link_show'   => self::router()->generateUrl('filemanager.show', [
-                        ':path' => $path
+                        'path' => $path
                     ]),
                     'nb_dir'      => $nbDir,
                     'nb_file'     => $nbFile,
@@ -203,7 +203,7 @@ class Manager extends \Soosyze\Controller
             'granted_folder_create' => $hookUser->hookFolderStore($path),
             'links'                 => self::filemanager()->getBreadcrumb($path),
             'link_folder_create'    => self::router()->generateUrl('filemanager.folder.create', [
-                ':path' => $path
+                'path' => $path
             ]),
         ]);
 
@@ -213,10 +213,10 @@ class Manager extends \Soosyze\Controller
                 ->addVars([
                     'granted_file_create' => $hookUser->hookFileStore($path),
                     'link_show'           => self::router()->generateUrl('filemanager.show', [
-                        ':path' => $path
+                        'path' => $path
                     ]),
                     'link_file_create'    => self::router()->generateUrl('filemanager.file.create', [
-                        ':path' => $path
+                        'path' => $path
                     ])
                 ])
                 ->addBlock('breadcrumb', $breadcrumb)

--- a/core/modules/FileManager/Hook/ApiRoute.php
+++ b/core/modules/FileManager/Hook/ApiRoute.php
@@ -35,7 +35,7 @@ class ApiRoute implements \SoosyzeCore\System\ApiRouteInterface
         $routes[] = [
             'link'  => $this->router->generateUrl(
                 'filemanager.public',
-                [ ':path' => '/download' ]
+                [ 'path' => '/download' ]
             ),
             'route' => $this->alias->getAlias(
                 'filemanager/public/download',

--- a/core/modules/FileManager/Services/FileManager.php
+++ b/core/modules/FileManager/Services/FileManager.php
@@ -103,7 +103,7 @@ class FileManager
                 ? '<i class="fa fa-home" aria-hidden="true"></i> ' . t('Home')
                 : $value,
                 'link'       => $this->router->generateUrl($keyRoute, [
-                    ':path' => Util::cleanPath($nextPath)
+                    'path' => Util::cleanPath($nextPath)
                 ]),
                 'active'     => ''
             ];
@@ -127,7 +127,7 @@ class FileManager
             'actions'    => $this->getActionsFolder($path . $name, $info),
             'ext'        => 'dir',
             'link_show'  => $this->router->generateUrl($keyRoute, [
-                ':path' => Util::cleanPath("$path/" . $name)
+                'path' => Util::cleanPath("$path/" . $name)
             ]),
             'name'       => $name,
             'path'       => $dir->getPath(),
@@ -151,7 +151,7 @@ class FileManager
             'actions'    => $this->getActionsFile($file, $path),
             'ext'        => $ext,
             'link_show'  => $this->router->generateUrl('filemanager.file.show', [
-                ':path' => $path, ':name' => '/' . $name, ':ext'  => '.' . $ext
+                'path' => $path, 'name' => '/' . $name, 'ext'  => '.' . $ext
             ]),
             'name'       => $name,
             'path'       => $path,
@@ -174,7 +174,7 @@ class FileManager
                 'icon'       => 'fa fa-edit',
                 'key'        => 'filemanager.folder.edit',
                 'link'       => $this->router->generateUrl('filemanager.folder.edit', [
-                    ':path' => $path
+                    'path' => $path
                 ]),
                 'title_link' => t('Rename')
             ];
@@ -185,7 +185,7 @@ class FileManager
                 'icon'       => 'fa fa-times',
                 'key'        => 'filemanager.folder.remove',
                 'link'       => $this->router->generateUrl('filemanager.folder.remove', [
-                    ':path' => $path
+                    'path' => $path
                 ]),
                 'title_link' => t('Delete')
             ];
@@ -196,7 +196,7 @@ class FileManager
                 'icon'       => 'fa fa-download',
                 'key'        => 'filemanager.folder.download',
                 'link'       => $this->router->generateUrl('filemanager.folder.download', [
-                    ':path' => $path
+                    'path' => $path
                 ]),
                 'title_link' => 'Download',
                 'type'       => 'link'
@@ -249,7 +249,7 @@ class FileManager
                 'icon'       => 'far fa-eye',
                 'key'        => 'filemanager.file.show',
                 'link'       => $this->router->generateUrl('filemanager.file.show', [
-                    ':path' => $path, ':name' => $name, ':ext'  => '.' . $ext
+                    'path' => $path, 'name' => $name, 'ext'  => '.' . $ext
                 ]),
                 'title_link' => 'View',
                 'type'       => 'button'
@@ -261,7 +261,7 @@ class FileManager
                 'icon'       => 'fa fa-edit',
                 'key'        => 'filemanager.file.edit',
                 'link'       => $this->router->generateUrl('filemanager.file.edit', [
-                    ':path' => $path, ':name' => $name, ':ext'  => '.' . $ext
+                    'path' => $path, 'name' => $name, 'ext'  => '.' . $ext
                 ]),
                 'title_link' => 'Rename',
                 'type'       => 'button'
@@ -273,7 +273,7 @@ class FileManager
                 'icon'       => 'fa fa-times',
                 'key'        => 'filemanager.file.remove',
                 'link'       => $this->router->generateUrl('filemanager.file.remove', [
-                    ':path' => $path, ':name' => $name, ':ext'  => '.' . $ext
+                    'path' => $path, 'name' => $name, 'ext'  => '.' . $ext
                 ]),
                 'title_link' => 'Delete',
                 'type'       => 'button'
@@ -285,7 +285,7 @@ class FileManager
                 'icon'       => 'fa fa-download',
                 'key'        => 'filemanager.file.download',
                 'link'       => $this->router->generateUrl('filemanager.file.download', [
-                    ':path' => $path, ':name' => $name, ':ext'  => '.' . $ext
+                    'path' => $path, 'name' => $name, 'ext'  => '.' . $ext
                 ]),
                 'title_link' => 'Download',
                 'type'       => 'link'
@@ -307,7 +307,7 @@ class FileManager
                 'icon'       => 'fa fa-copy',
                 'key'        => 'filemanager.copy.admin',
                 'link'       => $this->router->generateUrl('filemanager.copy.admin', [
-                    ':path' => $path, ':name' => $name, ':ext'  => '.' . $ext
+                    'path' => $path, 'name' => $name, 'ext'  => '.' . $ext
                 ]),
                 'title_link' => 'Deplace or copy',
                 'type'       => 'button'

--- a/core/modules/FileManager/Views/filemanager/content-file_permission_manager-admin.php
+++ b/core/modules/FileManager/Views/filemanager/content-file_permission_manager-admin.php
@@ -100,7 +100,7 @@
                     <div class="btn-group" role="group" aria-label="action">
                         <a class="btn btn-action" href="<?php
                             echo $router->generateUrl('filemanager.permission.edit', [
-                                ':id' => $profil[ 'profil_file_id' ] ]);
+                                'id' => $profil[ 'profil_file_id' ] ]);
                         ?>">
                             <i class="fa fa-edit" aria-hidden="true"></i> <?php echo t('Edit'); ?>
 
@@ -115,7 +115,7 @@
                                 <li>
                                     <a class="btn btn-action dropdown-item" href="<?php
                                         echo $router->generateUrl('filemanager.permission.remove', [
-                                            ':id' => $profil[ 'profil_file_id' ] ]);
+                                            'id' => $profil[ 'profil_file_id' ] ]);
                                     ?>">
                                         <i class="fa fa-times" aria-hidden="true"></i> <?php echo t('Delete'); ?>
 

--- a/core/modules/Menu/Config/routes.php
+++ b/core/modules/Menu/Config/routes.php
@@ -8,7 +8,7 @@ RouteCollection::setNamespace('SoosyzeCore\Menu\Controller')->name('menu.')->gro
 
     $r->prefix('/admin/menu')->group(function (RouteGroup $r): void {
         $r->setNamespace('\MenuManager')->group(function (RouteGroup $r): void {
-            $r->get('admin', '/', '@admin');
+            $r->get('admin', '/', '@show');
             $r->get('show', '/{menuId}', '@show')->whereDigits('menuId');
             $r->patch('check', '/{menuId}', '@check')->whereDigits('menuId');
         });

--- a/core/modules/Menu/Config/routes.php
+++ b/core/modules/Menu/Config/routes.php
@@ -4,31 +4,31 @@ use Soosyze\Components\Router\RouteCollection;
 use Soosyze\Components\Router\RouteGroup;
 
 RouteCollection::setNamespace('SoosyzeCore\Menu\Controller')->name('menu.')->group(function (RouteGroup $r): void {
-    $r->get('api.show', '/admin/api/menu/:menuId', '\MenuApi@show')->whereDigits(':menuId');
+    $r->get('api.show', '/admin/api/menu/{menuId}', '\MenuApi@show')->whereDigits('menuId');
 
     $r->prefix('/admin/menu')->group(function (RouteGroup $r): void {
         $r->setNamespace('\MenuManager')->group(function (RouteGroup $r): void {
             $r->get('admin', '/', '@admin');
-            $r->get('show', '/:menuId', '@show')->whereDigits(':menuId');
-            $r->patch('check', '/:menuId', '@check')->whereDigits(':menuId');
+            $r->get('show', '/{menuId}', '@show')->whereDigits('menuId');
+            $r->patch('check', '/{menuId}', '@check')->whereDigits('menuId');
         });
         $r->setNamespace('\Menu')->group(function (RouteGroup $r) {
             $r->get('create', '/create', '@create');
             $r->post('store', '/create', '@store');
-            $r->get('edit', '/:menuId/edit', '@edit')->whereDigits(':menuId');
-            $r->put('update', '/:menuId', '@update')->whereDigits(':menuId');
-            $r->get('remove', '/:menuId/delete', '@remove')->whereDigits(':menuId');
-            $r->delete('delete', '/:menuId', '@delete')->whereDigits(':menuId');
+            $r->get('edit', '/{menuId}/edit', '@edit')->whereDigits('menuId');
+            $r->put('update', '/{menuId}', '@update')->whereDigits('menuId');
+            $r->get('remove', '/{menuId}/delete', '@remove')->whereDigits('menuId');
+            $r->delete('delete', '/{menuId}', '@delete')->whereDigits('menuId');
         });
 
-        $r->prefix('/:menuId/link')->withs([ ':menuId' => '\d+' ])->name('link.')->setNamespace('\Link')->group(function (RouteGroup $r): void {
+        $r->prefix('/{menuId}/link')->withs([ 'menuId' => '\d+' ])->name('link.')->setNamespace('\Link')->group(function (RouteGroup $r): void {
             $r->get('create', '/', '@create');
             $r->post('store', '/', '@store');
-            $r->get('edit', '/:linkId/edit', '@edit')->whereDigits(':linkId');
-            $r->put('update', '/:linkId', '@update')->whereDigits(':linkId');
-            $r->get('remove', '/:linkId/delete', '@remove')->whereDigits(':linkId');
-            $r->get('remove.modal', '/:linkId/delete/modal', '@removeModal')->whereDigits(':linkId');
-            $r->delete('delete', '/:linkId', '@delete')->whereDigits(':linkId');
+            $r->get('edit', '/{linkId}/edit', '@edit')->whereDigits('linkId');
+            $r->put('update', '/{linkId}', '@update')->whereDigits('linkId');
+            $r->get('remove', '/{linkId}/delete', '@remove')->whereDigits('linkId');
+            $r->get('remove.modal', '/{linkId}/delete/modal', '@removeModal')->whereDigits('linkId');
+            $r->delete('delete', '/{linkId}', '@delete')->whereDigits('linkId');
         });
     });
 });

--- a/core/modules/Menu/Controller/Link.php
+++ b/core/modules/Menu/Controller/Link.php
@@ -31,7 +31,7 @@ class Link extends \Soosyze\Controller
         $values = [ 'menu_id' => $menuId ];
         $this->container->callHook('menu.link.create.form.data', [ &$values ]);
 
-        $action = self::router()->generateUrl('menu.link.store', [ ':menuId' => $menuId ]);
+        $action = self::router()->generateUrl('menu.link.store', [ 'menuId' => $menuId ]);
 
         $form = (new FormLink([ 'action' => $action, 'method' => 'post' ], self::router()))
             ->setValues($values)
@@ -78,7 +78,7 @@ class Link extends \Soosyze\Controller
 
             return $this->json(201, [
                     'redirect' => self::router()->generateUrl('menu.show', [
-                        ':menuId' => $menuId
+                        'menuId' => $menuId
                     ])
             ]);
         }
@@ -98,8 +98,8 @@ class Link extends \Soosyze\Controller
         $this->container->callHook('menu.link.edit.form.data', [ &$values ]);
 
         $action = self::router()->generateUrl('menu.link.update', [
-            ':menuId' => $menuId,
-            ':linkId' => $linkId
+            'menuId' => $menuId,
+            'linkId' => $linkId
         ]);
 
         $form = (new FormLink([ 'action' => $action, 'method' => 'put' ], self::router()))
@@ -148,7 +148,7 @@ class Link extends \Soosyze\Controller
 
             return $this->json(200, [
                     'redirect' => self::router()->generateUrl('menu.show', [
-                        ':menuId' => $menuId
+                        'menuId' => $menuId
                     ])
             ]);
         }
@@ -234,7 +234,7 @@ class Link extends \Soosyze\Controller
             $_SESSION[ 'messages' ][ 'success' ][] = t('Saved configuration');
 
             return $this->json(200, [
-                    'redirect' => self::router()->generateUrl('menu.show', [ ':menuId' => $menuId ])
+                    'redirect' => self::router()->generateUrl('menu.show', [ 'menuId' => $menuId ])
             ]);
         }
 
@@ -249,8 +249,8 @@ class Link extends \Soosyze\Controller
         $this->container->callHook('menu.link.remove.form.data', [ &$values ]);
 
         $action = self::router()->generateUrl('menu.link.delete', [
-            ':menuId' => $values[ 'menu_id' ],
-            ':linkId' => $values[ 'link_id' ]
+            'menuId' => $values[ 'menu_id' ],
+            'linkId' => $values[ 'link_id' ]
         ]);
 
         $form = (new FormBuilder([ 'action' => $action, 'class' => 'form-api', 'method' => 'delete' ]))

--- a/core/modules/Menu/Controller/Menu.php
+++ b/core/modules/Menu/Controller/Menu.php
@@ -73,7 +73,7 @@ class Menu extends \Soosyze\Controller
             $menuId = self::schema()->getIncrement('menu');
 
             return $this->json(201, [
-                    'redirect' => self::router()->generateUrl('menu.show', [ ':menuId' => $menuId ])
+                    'redirect' => self::router()->generateUrl('menu.show', [ 'menuId' => $menuId ])
             ]);
         }
 
@@ -93,7 +93,7 @@ class Menu extends \Soosyze\Controller
 
         $this->container->callHook('menu.store.form.data', [ &$values ]);
 
-        $action = self::router()->generateUrl('menu.update', [ ':menuId' => $menuId ]);
+        $action = self::router()->generateUrl('menu.update', [ 'menuId' => $menuId ]);
 
         $form = (new FormMenu(['action' => $action, 'method' => 'put' ]))
             ->setValues($values)
@@ -140,7 +140,7 @@ class Menu extends \Soosyze\Controller
             $_SESSION[ 'messages' ][ 'success' ][] = t('Saved configuration');
 
             return $this->json(200, [
-                    'redirect' => self::router()->generateUrl('menu.show', [ ':menuId' => $menuId ])
+                    'redirect' => self::router()->generateUrl('menu.show', [ 'menuId' => $menuId ])
             ]);
         }
 
@@ -160,7 +160,7 @@ class Menu extends \Soosyze\Controller
 
         $this->container->callHook('menu.remove.form.data', [ &$values, $menuId ]);
 
-        $action = self::router()->generateUrl('menu.delete', [ ':menuId' => $menuId ]);
+        $action = self::router()->generateUrl('menu.delete', [ 'menuId' => $menuId ]);
 
         $form = (new FormBuilder([ 'action' => $action, 'class' => 'form-api', 'method' => 'delete' ]))
             ->group('menu-fieldset', 'fieldset', function ($form) {

--- a/core/modules/Menu/Controller/MenuManager.php
+++ b/core/modules/Menu/Controller/MenuManager.php
@@ -24,12 +24,7 @@ class MenuManager extends \Soosyze\Controller
         $this->pathViews    = dirname(__DIR__) . '/Views/';
     }
 
-    public function admin(ServerRequestInterface $req): ResponseInterface
-    {
-        return $this->show(Menu::MAIN_MENU, $req);
-    }
-
-    public function show(int $menuId, ServerRequestInterface $req): ResponseInterface
+    public function show(ServerRequestInterface $req, int $menuId = Menu::MAIN_MENU): ResponseInterface
     {
         /** @phpstan-var MenuEntity|null $menu */
         $menu = self::menu()->getMenu($menuId)->fetch();

--- a/core/modules/Menu/Controller/MenuManager.php
+++ b/core/modules/Menu/Controller/MenuManager.php
@@ -37,7 +37,7 @@ class MenuManager extends \Soosyze\Controller
             return $this->get404($req);
         }
 
-        $action = self::router()->generateUrl('menu.check', [ ':menuId' => $menuId ]);
+        $action = self::router()->generateUrl('menu.check', [ 'menuId' => $menuId ]);
 
         $form = (new FormBuilder([ 'action' => $action, 'class' => 'form-api', 'method' => 'patch' ]))
             ->group('submit-group', 'div', function ($form) {
@@ -55,7 +55,7 @@ class MenuManager extends \Soosyze\Controller
                 ->make('page.content', 'menu/content-menu-show.php', $this->pathViews, [
                     'form'              => $form,
                     'link_create_link'  => self::router()->generateUrl('menu.link.create', [
-                        ':menuId' => $menuId
+                        'menuId' => $menuId
                     ]),
                     'link_create_menu'  => self::router()->generateUrl('menu.create'),
                     'list_menu_submenu' => $this->getListMenuSubmenu($menuId),
@@ -66,7 +66,7 @@ class MenuManager extends \Soosyze\Controller
 
     public function check(int $menuId, ServerRequestInterface $req): ResponseInterface
     {
-        $route = self::router()->generateUrl('menu.show', [ ':menuId' => $menuId ]);
+        $route = self::router()->generateUrl('menu.show', [ 'menuId' => $menuId ]);
         if (!($links = self::menu()->getLinkPerMenu($menuId)->fetchAll())) {
             return $this->json(200, [ 'redirect' => $route ]);
         }
@@ -127,7 +127,7 @@ class MenuManager extends \Soosyze\Controller
 
         foreach ($menus as &$menu) {
             $menu[ 'link' ] = self::router()
-                ->generateUrl('menu.show', [ ':menuId' => $menu[ 'menu_id' ] ]);
+                ->generateUrl('menu.show', [ 'menuId' => $menu[ 'menu_id' ] ]);
         }
         unset($menu);
 
@@ -154,16 +154,16 @@ class MenuManager extends \Soosyze\Controller
                 ->generateUrl(
                     'menu.link.edit',
                     [
-                        ':menuId' => $link[ 'menu_id' ],
-                        ':linkId' => $link[ 'link_id' ]
+                        'menuId' => $link[ 'menu_id' ],
+                        'linkId' => $link[ 'link_id' ]
                     ]
                 );
             $link[ 'link_remove' ] = self::router()
                 ->generateUrl(
                     'menu.link.remove.modal',
                     [
-                        ':menuId' => $link[ 'menu_id' ],
-                        ':linkId' => $link[ 'link_id' ]
+                        'menuId' => $link[ 'menu_id' ],
+                        'linkId' => $link[ 'link_id' ]
                     ]
                 );
             $link[ 'submenu' ]     = $link[ 'has_children' ]

--- a/core/modules/Menu/Hook/Block.php
+++ b/core/modules/Menu/Hook/Block.php
@@ -201,7 +201,7 @@ class Block implements \SoosyzeCore\Block\BlockInterface
             $options[] = [
                 'attr'  => [
                     'data-link' => $this->router->generateUrl('menu.api.show', [
-                        ':menuId' => $menu[ 'menu_id' ]
+                        'menuId' => $menu[ 'menu_id' ]
                     ])
                 ],
                 'label' => t($menu[ 'title' ]),

--- a/core/modules/Menu/Services/Menu.php
+++ b/core/modules/Menu/Services/Menu.php
@@ -244,19 +244,19 @@ class Menu
             [
                 'key'        => 'menu.show',
                 'request'    => $this->router->generateRequest('menu.show', [
-                    ':menuId' => $menuId
+                    'menuId' => $menuId
                 ]),
                 'title_link' => 'View'
             ], [
                 'key'        => 'menu.edit',
                 'request'    => $this->router->generateRequest('menu.edit', [
-                    ':menuId' => $menuId
+                    'menuId' => $menuId
                 ]),
                 'title_link' => 'Edit'
             ], [
                 'key'        => 'menu.remove',
                 'request'    => $this->router->generateRequest('menu.remove', [
-                    ':menuId' => $menuId
+                    'menuId' => $menuId
                 ]),
                 'title_link' => 'Delete'
             ]
@@ -286,13 +286,13 @@ class Menu
             [
                 'key'        => 'menu.link.edit',
                 'request'    => $this->router->generateRequest('menu.link.edit', [
-                    ':menuId' => $menuId, ':linkId' => $linkId
+                    'menuId' => $menuId, 'linkId' => $linkId
                 ]),
                 'title_link' => 'Edit'
             ], [
                 'key'        => 'menu.link.remove',
                 'request'    => $this->router->generateRequest('menu.link.remove', [
-                    ':menuId' => $menuId, ':linkId' => $linkId
+                    'menuId' => $menuId, 'linkId' => $linkId
                 ]),
                 'title_link' => 'Delete'
             ]

--- a/core/modules/News/Config/routes.php
+++ b/core/modules/News/Config/routes.php
@@ -4,20 +4,20 @@ use Soosyze\Components\Router\RouteCollection;
 use Soosyze\Components\Router\RouteGroup;
 
 RouteCollection::setNamespace('SoosyzeCore\News\Controller\News')->name('news.')->prefix('/news')->group(function (RouteGroup $r): void {
-    $r->get('index', '', '@index');
+    $r->get('index', '/', '@page');
     $r->get('page', '/page/{pageId}', '@page', [ 'pageId' => '[1-9]\d*' ]);
 
     $r->prefix('/{year}')->withs([ 'year' => '\d{4}' ])->group(function (RouteGroup $r): void {
-        $r->get('years', '{pageId}', '@viewYears', [ 'pageId' => '(/page/[1-9]\d*)?' ]);
+        $r->get('years', '/', '@viewYears');
         $r->get('years.page', '/page/{pageId}', '@viewYears', [ 'pageId' => '[1-9]\d*' ]);
 
         $r->prefix('/{month}')->withs([ 'month' => '0[1-9]|1[0-2]' ])->group(function (RouteGroup $r): void {
-            $r->get('month', '{pageId}', '@viewMonth', [ 'pageId' => '(/page/[1-9]\d*)?' ]);
+            $r->get('month', '/', '@viewMonth');
             $r->get('month.page', '/page/{pageId}', '@viewMonth', [ 'pageId' => '[1-9]\d*' ]);
 
             $r->prefix('/{day}')->withs([ 'day' => '[0-2][1-9]|3[0-1]' ])->group(function (RouteGroup $r): void {
-                $r->get('day', '{pageId}', '@viewDay', [ 'pageId' => '(/page/[1-9]\d*)?' ]);
-                $r->get('day.page', '/page/{pageId}', 'News@viewDay', [ 'pageId' => '[1-9]\d*' ]);
+                $r->get('day', '/', '@viewDay');
+                $r->get('day.page', '/page/{pageId}', '@viewDay', [ 'pageId' => '[1-9]\d*' ]);
             });
         });
     });

--- a/core/modules/News/Config/routes.php
+++ b/core/modules/News/Config/routes.php
@@ -5,19 +5,19 @@ use Soosyze\Components\Router\RouteGroup;
 
 RouteCollection::setNamespace('SoosyzeCore\News\Controller\News')->name('news.')->prefix('/news')->group(function (RouteGroup $r): void {
     $r->get('index', '', '@index');
-    $r->get('page', '/page/:id', '@page', [ ':id' => '[1-9]\d*' ]);
+    $r->get('page', '/page/{pageId}', '@page', [ 'pageId' => '[1-9]\d*' ]);
 
-    $r->prefix('/:year')->withs([ ':year' => '\d{4}' ])->group(function (RouteGroup $r): void {
-        $r->get('years', ':id', '@viewYears', [ ':id' => '(/page/[1-9]\d*)?' ]);
-        $r->get('years.page', '/page/:id', '@viewYears', [ ':id' => '[1-9]\d*' ]);
+    $r->prefix('/{year}')->withs([ 'year' => '\d{4}' ])->group(function (RouteGroup $r): void {
+        $r->get('years', '{pageId}', '@viewYears', [ 'pageId' => '(/page/[1-9]\d*)?' ]);
+        $r->get('years.page', '/page/{pageId}', '@viewYears', [ 'pageId' => '[1-9]\d*' ]);
 
-        $r->prefix('/:month')->withs([ ':month' => '0[1-9]|1[0-2]' ])->group(function (RouteGroup $r): void {
-            $r->get('month', ':id', '@viewMonth', [ ':id' => '(/page/[1-9]\d*)?' ]);
-            $r->get('month.page', '/page/:id', '@viewMonth', [ ':id' => '[1-9]\d*' ]);
+        $r->prefix('/{month}')->withs([ 'month' => '0[1-9]|1[0-2]' ])->group(function (RouteGroup $r): void {
+            $r->get('month', '{pageId}', '@viewMonth', [ 'pageId' => '(/page/[1-9]\d*)?' ]);
+            $r->get('month.page', '/page/{pageId}', '@viewMonth', [ 'pageId' => '[1-9]\d*' ]);
 
-            $r->prefix('/:day')->withs([ ':day' => '[0-2][1-9]|3[0-1]' ])->group(function (RouteGroup $r): void {
-                $r->get('day', ':id', '@viewDay', [ ':id' => '(/page/[1-9]\d*)?' ]);
-                $r->get('day.page', '/page/:id', 'News@viewDay', [ ':id' => '[1-9]\d*' ]);
+            $r->prefix('/{day}')->withs([ 'day' => '[0-2][1-9]|3[0-1]' ])->group(function (RouteGroup $r): void {
+                $r->get('day', '{pageId}', '@viewDay', [ 'pageId' => '(/page/[1-9]\d*)?' ]);
+                $r->get('day.page', '/page/{pageId}', 'News@viewDay', [ 'pageId' => '[1-9]\d*' ]);
             });
         });
     });

--- a/core/modules/News/Controller/News.php
+++ b/core/modules/News/Controller/News.php
@@ -48,12 +48,7 @@ class News extends \Soosyze\Controller
         $this->pathViews    = dirname(__DIR__) . '/Views/';
     }
 
-    public function index(ServerRequestInterface $req): ResponseInterface
-    {
-        return $this->page(1, $req);
-    }
-
-    public function page(int $pageId, ServerRequestInterface $req): ResponseInterface
+    public function page(ServerRequestInterface $req, int $pageId = 1): ResponseInterface
     {
         /** @phpstan-var int $limit */
         $limit = self::config()->get('settings.news_pagination', Config::PAGINATION);
@@ -110,7 +105,7 @@ class News extends \Soosyze\Controller
         ]);
     }
 
-    public function viewYears(string $year, string $pageId, ServerRequestInterface $req): ResponseInterface
+    public function viewYears(string $year, ServerRequestInterface $req, int $pageId = 1): ResponseInterface
     {
         $date              = '01/01/' . $year;
         $this->dateCurrent = self::tryStrtotime($date);
@@ -121,7 +116,7 @@ class News extends \Soosyze\Controller
         return $this->renderNews($pageId, $req);
     }
 
-    public function viewMonth(string $year, string $month, string $pageId, ServerRequestInterface $req): ResponseInterface
+    public function viewMonth(string $year, string $month, ServerRequestInterface $req, int $pageId = 1): ResponseInterface
     {
         $date              = $month . '/01/' . $year;
         $this->dateCurrent = self::tryStrtotime($date);
@@ -135,7 +130,7 @@ class News extends \Soosyze\Controller
         return $this->renderNews($pageId, $req);
     }
 
-    public function viewDay(string $year, string $month, string $day, string $pageId, ServerRequestInterface $req): ResponseInterface
+    public function viewDay(string $year, string $month, string $day, ServerRequestInterface $req, int $pageId = 1): ResponseInterface
     {
         $date              = $month . '/' . $day . '/' . $year;
         $this->dateCurrent = self::tryStrtotime($date);
@@ -199,12 +194,8 @@ class News extends \Soosyze\Controller
                 ->withHeader('expires', '0');
     }
 
-    private function renderNews(string $pageId, ServerRequestInterface $req): ResponseInterface
+    private function renderNews(int $pageId, ServerRequestInterface $req): ResponseInterface
     {
-        $pageId = empty($pageId)
-            ? 1
-            : (int) ltrim($pageId, '/page/');
-
         /** @phpstan-var int $limit */
         $limit = self::config()->get('settings.news_pagination', Config::PAGINATION);
 

--- a/core/modules/News/Hook/Block.php
+++ b/core/modules/News/Hook/Block.php
@@ -125,8 +125,7 @@ class Block implements \SoosyzeCore\Block\BlockInterface
                         $year => [
                             'label' => t('All {year}', [ 'year' => $year ]),
                             'value' => $this->router->generateUrl('news.years', [
-                                'year'   => $year,
-                                'pageId' => ''
+                                'year'   => $year
                             ])
                         ]
                     ]
@@ -141,8 +140,7 @@ class Block implements \SoosyzeCore\Block\BlockInterface
                 'label' => strftime('%b', (int) $value[ 'date_created' ]),
                 'value' => $this->router->generateUrl('news.month', [
                     'year'   => $year,
-                    'month'  => $month,
-                    'pageId' => ''
+                    'month'  => $month
                 ])
             ];
         }
@@ -151,13 +149,11 @@ class Block implements \SoosyzeCore\Block\BlockInterface
         if (!empty($paramMonth)) {
             $selected = $this->router->generateUrl('news.month', [
                 'year'   => $paramMonth[ 0 ],
-                'month'  => $paramMonth[ 1 ],
-                'pageId' => ''
+                'month'  => $paramMonth[ 1 ]
             ]);
         } elseif (!empty($paramYear)) {
             $selected = $this->router->generateUrl('news.years', [
-                'year'   => $paramYear[ 0 ],
-                'pageId' => ''
+                'year'   => $paramYear[ 0 ]
             ]);
         }
 
@@ -193,8 +189,7 @@ class Block implements \SoosyzeCore\Block\BlockInterface
             } else {
                 $output[ $year ] = [
                     'link'   => $this->router->generateUrl('news.years', [
-                        'year'   => $year,
-                        'pageId' => ''
+                        'year'   => $year
                     ]),
                     'number' => 1,
                     'year'   => $year
@@ -211,8 +206,7 @@ class Block implements \SoosyzeCore\Block\BlockInterface
                 $output[ $year ][ 'months' ][ $month ] = [
                     'link'   => $this->router->generateUrl('news.month', [
                         'year'   => $year,
-                        'month'  => $month,
-                        'pageId' => ''
+                        'month'  => $month
                     ]),
                     'month'  => strftime('%b', (int) $value[ 'date_created' ]),
                     'number' => 1,

--- a/core/modules/News/Hook/Block.php
+++ b/core/modules/News/Hook/Block.php
@@ -123,10 +123,10 @@ class Block implements \SoosyzeCore\Block\BlockInterface
                     'label' => $year,
                     'value' => [
                         $year => [
-                            'label' => t('All :year', [ ':year' => $year ]),
+                            'label' => t('All {year}', [ 'year' => $year ]),
                             'value' => $this->router->generateUrl('news.years', [
-                                ':year' => $year,
-                                ':id'   => ''
+                                'year'   => $year,
+                                'pageId' => ''
                             ])
                         ]
                     ]
@@ -140,9 +140,9 @@ class Block implements \SoosyzeCore\Block\BlockInterface
             $optionsSelect[ $year ][ 'value' ][ $month ] = [
                 'label' => strftime('%b', (int) $value[ 'date_created' ]),
                 'value' => $this->router->generateUrl('news.month', [
-                    ':year'  => $year,
-                    ':month' => $month,
-                    ':id'    => ''
+                    'year'   => $year,
+                    'month'  => $month,
+                    'pageId' => ''
                 ])
             ];
         }
@@ -150,14 +150,14 @@ class Block implements \SoosyzeCore\Block\BlockInterface
         $selected = '#';
         if (!empty($paramMonth)) {
             $selected = $this->router->generateUrl('news.month', [
-                ':year'  => $paramMonth[ 0 ],
-                ':month' => $paramMonth[ 1 ],
-                ':id'    => ''
+                'year'   => $paramMonth[ 0 ],
+                'month'  => $paramMonth[ 1 ],
+                'pageId' => ''
             ]);
         } elseif (!empty($paramYear)) {
             $selected = $this->router->generateUrl('news.years', [
-                ':year' => $paramYear[ 0 ],
-                ':id'   => ''
+                'year'   => $paramYear[ 0 ],
+                'pageId' => ''
             ]);
         }
 
@@ -193,8 +193,8 @@ class Block implements \SoosyzeCore\Block\BlockInterface
             } else {
                 $output[ $year ] = [
                     'link'   => $this->router->generateUrl('news.years', [
-                        ':year' => $year,
-                        ':id'   => ''
+                        'year'   => $year,
+                        'pageId' => ''
                     ]),
                     'number' => 1,
                     'year'   => $year
@@ -210,9 +210,9 @@ class Block implements \SoosyzeCore\Block\BlockInterface
             } else {
                 $output[ $year ][ 'months' ][ $month ] = [
                     'link'   => $this->router->generateUrl('news.month', [
-                        ':year'  => $year,
-                        ':month' => $month,
-                        ':id'    => ''
+                        'year'   => $year,
+                        'month'  => $month,
+                        'pageId' => ''
                     ]),
                     'month'  => strftime('%b', (int) $value[ 'date_created' ]),
                     'number' => 1,

--- a/core/modules/Node/Config/routes.php
+++ b/core/modules/Node/Config/routes.php
@@ -4,25 +4,25 @@ use Soosyze\Components\Router\RouteCollection;
 use Soosyze\Components\Router\RouteGroup;
 
 define('ENTITY_STORE_WITH', [
-    ':idNode' => '\d+',
-    ':entity'  => '[_a-z]+'
+    'idNode' => '\d+',
+    'entity'  => '[_a-z]+'
 ]);
 define('ENTITY_EDIT_WITH', [
-    ':idNode'   => '\d+',
-    ':entity'    => '[_a-z]+',
-    ':idEntity' => '\d+'
+    'idNode'   => '\d+',
+    'entity'    => '[_a-z]+',
+    'idEntity' => '\d+'
 ]);
 
 RouteCollection::setNamespace('SoosyzeCore\Node\Controller')->name('node.')->prefix('/node')->group(function (RouteGroup $r): void {
-    $r->get('show', '/:idNode', '\Node@show', [ ':idNode' => '\d+' ]);
+    $r->get('show', '/{idNode}', '\Node@show', [ 'idNode' => '\d+' ]);
     $r->get('status.search', '/status/search', '\NodeStatus@search');
     $r->get('type.search', '/type/search', '\NodeType@search');
     $r->get('filter', '/filter', '\NodeManager@filter');
-    $r->get('filter.page', '/filter/:id', '\NodeManager@filterPage', [ ':id' => '[1-9]\d*' ]);
+    $r->get('filter.page', '/filter/{pageId}', '\NodeManager@filterPage', [ 'pageId' => '[1-9]\d*' ]);
 });
-RouteCollection::setNamespace('SoosyzeCore\Node\Controller\NodeApi')->name('node.api.')->prefix('/api/node/:idNode')->group(function (RouteGroup $r): void {
-    $r->get('remove', '/remove', '@remove', [ ':idNode' => '\d+' ]);
-    $r->delete('delete', '/delete', '@delete', [ ':idNode' => '\d+' ]);
+RouteCollection::setNamespace('SoosyzeCore\Node\Controller\NodeApi')->name('node.api.')->prefix('/api/node/{idNode}')->group(function (RouteGroup $r): void {
+    $r->get('remove', '/remove', '@remove', [ 'idNode' => '\d+' ]);
+    $r->delete('delete', '/delete', '@delete', [ 'idNode' => '\d+' ]);
 });
 RouteCollection::setNamespace('SoosyzeCore\Node\Controller')->prefix('/admin/node')->name('node.')->group(function (RouteGroup $r): void {
     $r->setNamespace('\NodeManager')->group(function (RouteGroup $r): void {
@@ -30,21 +30,21 @@ RouteCollection::setNamespace('SoosyzeCore\Node\Controller')->prefix('/admin/nod
     });
     $r->setNamespace('\Node')->group(function (RouteGroup $r): void {
         $r->get('add', '/add', '@add');
-        $r->get('create', '/:node/create', '@create', [ ':node' => '[_a-z]+' ]);
-        $r->post('store', '/:node/create', '@store', [ ':node' => '[_a-z]+' ]);
-        $r->get('edit', '/:idNode/edit', '@edit', [ ':idNode' => '\d+' ]);
-        $r->put('update', '/:idNode/edit', '@update', [ ':idNode' => '\d+' ]);
-        $r->get('remove', '/:idNode/remove', '@remove', [ ':idNode' => '\d+' ]);
-        $r->delete('delete', '/:idNode/delete', '@delete', [ ':idNode' => '\d+' ]);
+        $r->get('create', '/{node}/create', '@create', [ 'node' => '[_a-z]+' ]);
+        $r->post('store', '/{node}/create', '@store', [ 'node' => '[_a-z]+' ]);
+        $r->get('edit', '/{idNode}/edit', '@edit', [ 'idNode' => '\d+' ]);
+        $r->put('update', '/{idNode}/edit', '@update', [ 'idNode' => '\d+' ]);
+        $r->get('remove', '/{idNode}/remove', '@remove', [ 'idNode' => '\d+' ]);
+        $r->delete('delete', '/{idNode}/delete', '@delete', [ 'idNode' => '\d+' ]);
     });
     $r->setNamespace('\NodeClone')->group(function (RouteGroup $r): void {
-        $r->get('clone', '/:idNode/clone', '@duplicate', [ ':idNode' => '\d+' ]);
+        $r->get('clone', '/{idNode}/clone', '@duplicate', [ 'idNode' => '\d+' ]);
     });
-    $r->setNamespace('\Entity')->name('entity.')->prefix('/:idNode/:entity')->group(function (RouteGroup $r): void {
+    $r->setNamespace('\Entity')->name('entity.')->prefix('/{idNode}/{entity}')->group(function (RouteGroup $r): void {
         $r->get('create', '/', '@create', ENTITY_STORE_WITH);
         $r->post('store', '/', '@store', ENTITY_STORE_WITH);
-        $r->get('edit', '/:idEntity/edit', '@edit', ENTITY_EDIT_WITH);
-        $r->put('update', '/:idEntity/edit', '@update', ENTITY_EDIT_WITH);
-        $r->delete('delete', '/:idEntity/delete', '@delete', ENTITY_EDIT_WITH);
+        $r->get('edit', '/{idEntity}/edit', '@edit', ENTITY_EDIT_WITH);
+        $r->put('update', '/{idEntity}/edit', '@update', ENTITY_EDIT_WITH);
+        $r->delete('delete', '/{idEntity}/delete', '@delete', ENTITY_EDIT_WITH);
     });
 });

--- a/core/modules/Node/Config/routes.php
+++ b/core/modules/Node/Config/routes.php
@@ -18,7 +18,7 @@ RouteCollection::setNamespace('SoosyzeCore\Node\Controller')->name('node.')->pre
     $r->get('status.search', '/status/search', '\NodeStatus@search');
     $r->get('type.search', '/type/search', '\NodeType@search');
     $r->get('filter', '/filter', '\NodeManager@filter');
-    $r->get('filter.page', '/filter/{pageId}', '\NodeManager@filterPage', [ 'pageId' => '[1-9]\d*' ]);
+    $r->get('filter.page', '/filter/{pageId}', '\NodeManager@filter', [ 'pageId' => '[1-9]\d*' ]);
 });
 RouteCollection::setNamespace('SoosyzeCore\Node\Controller\NodeApi')->name('node.api.')->prefix('/api/node/{idNode}')->group(function (RouteGroup $r): void {
     $r->get('remove', '/remove', '@remove', [ 'idNode' => '\d+' ]);

--- a/core/modules/Node/Controller/Entity.php
+++ b/core/modules/Node/Controller/Entity.php
@@ -49,8 +49,8 @@ class Entity extends \Soosyze\Controller
 
         $form = (new FormNode([
             'action'  => self::router()->generateUrl('node.entity.store', [
-                ':idNode' => $idNode,
-                ':entity' => $entity
+                'idNode' => $idNode,
+                'entity' => $entity
             ]),
             'enctype' => 'multipart/form-data',
             'method'  => 'post' ], self::file(), self::query(), self::router(), self::config()))
@@ -163,7 +163,7 @@ class Entity extends \Soosyze\Controller
             $_SESSION[ 'messages' ][ 'success' ][] = t('Your content has been saved.');
 
             return $this->json(201, [
-                'redirect' => self::router()->generateUrl('node.edit', [ ':idNode' => $idNode ])
+                'redirect' => self::router()->generateUrl('node.edit', [ 'idNode' => $idNode ])
             ]);
         }
 
@@ -194,9 +194,9 @@ class Entity extends \Soosyze\Controller
 
         $form = (new FormNode([
             'action'  => self::router()->generateUrl('node.entity.update', [
-                ':idNode'   => $idNode,
-                ':entity'   => $entity,
-                ':idEntity' => $idEntity
+                'idNode'   => $idNode,
+                'entity'   => $entity,
+                'idEntity' => $idEntity
             ]),
             'enctype' => 'multipart/form-data',
             'method'  => 'put' ], self::file(), self::query(), self::router(), self::config()))
@@ -298,7 +298,7 @@ class Entity extends \Soosyze\Controller
             $_SESSION[ 'messages' ][ 'success' ][] = t('Saved configuration');
 
             return $this->json(200, [
-                'redirect' => self::router()->generateUrl('node.edit', [ ':idNode' => $idNode ])
+                'redirect' => self::router()->generateUrl('node.edit', [ 'idNode' => $idNode ])
             ]);
         }
 
@@ -354,9 +354,9 @@ class Entity extends \Soosyze\Controller
 
             return $this->json(200, [
                     'redirect' => self::router()->generateUrl('node.edit', [
-                        ':idNode'   => $idNode,
-                        ':entity'   => $typeEntity,
-                        ':idEntity' => $idEntity
+                        'idNode'   => $idNode,
+                        'entity'   => $typeEntity,
+                        'idEntity' => $idEntity
                     ])
             ]);
         }

--- a/core/modules/Node/Controller/Node.php
+++ b/core/modules/Node/Controller/Node.php
@@ -51,13 +51,13 @@ class Node extends \Soosyze\Controller
 
         foreach ($nodeType as $key => &$value) {
             $reqGranted = self::router()->generateRequest('node.create', [
-                ':node' => $value[ 'node_type' ]
+                'node' => $value[ 'node_type' ]
             ]);
             if (!$this->container->callHook('app.granted.request', [ $reqGranted ])) {
                 unset($nodeType[ $key ]);
             }
             $value[ 'link' ] = self::router()->generateUrl('node.create', [
-                ':node' => $value[ 'node_type' ]
+                'node' => $value[ 'node_type' ]
             ]);
         }
         unset($value);
@@ -84,7 +84,7 @@ class Node extends \Soosyze\Controller
         $this->container->callHook('node.create.form.data', [ &$values, $type ]);
 
         $form = (new FormNode([
-                'action'        => self::router()->generateUrl('node.store', [ ':node' => $type ]),
+                'action'        => self::router()->generateUrl('node.store', [ 'node' => $type ]),
                 'data-tab-pane' => '.pane-node',
                 'enctype'       => 'multipart/form-data',
                 'id'            => 'form-node',
@@ -182,7 +182,7 @@ class Node extends \Soosyze\Controller
 
             return $this->json(201, [
                 'redirect' => $fieldsRelation
-                    ? self::router()->generateUrl('node.edit', [ ':idNode' => $data[ 'id' ] ])
+                    ? self::router()->generateUrl('node.edit', [ 'idNode' => $data[ 'id' ] ])
                     : self::router()->generateUrl('node.admin')
             ]);
         }
@@ -258,7 +258,7 @@ class Node extends \Soosyze\Controller
         $this->container->callHook('node.edit.form.data', [ &$values, $idNode ]);
 
         $form = (new FormNode([
-                'action'        => self::router()->generateUrl('node.update', [ ':idNode' => $idNode ]),
+                'action'        => self::router()->generateUrl('node.update', [ 'idNode' => $idNode ]),
                 'data-tab-pane' => '.pane-node',
                 'enctype'       => 'multipart/form-data',
                 'id'            => 'form-node',
@@ -352,7 +352,7 @@ class Node extends \Soosyze\Controller
 
             return $this->json(200, [
                     'redirect' => self::router()->generateUrl('node.edit', [
-                        ':idNode' => $idNode
+                        'idNode' => $idNode
                     ])
             ]);
         }
@@ -391,7 +391,7 @@ class Node extends \Soosyze\Controller
 
         $this->container->callHook('node.remove.form.data', [ &$node, $idNode ]);
 
-        $action = self::router()->generateUrl('node.delete', [ ':idNode' => $idNode ]);
+        $action = self::router()->generateUrl('node.delete', [ 'idNode' => $idNode ]);
 
         $form = (new FormNodeDelete([ 'action' => $action, 'method' => 'delete' ], self::router()))
             ->setValues($values)
@@ -501,13 +501,13 @@ class Node extends \Soosyze\Controller
             [
                 'key'        => 'node.edit',
                 'request'    => self::router()->generateRequest('node.edit', [
-                    ':idNode' => $idNode
+                    'idNode' => $idNode
                 ]),
                 'title_link' => t('Edit')
             ], [
                 'key'        => 'node.delete',
                 'request'    => self::router()->generateRequest('node.remove', [
-                    ':idNode' => $idNode
+                    'idNode' => $idNode
                 ]),
                 'title_link' => t('Delete')
             ]
@@ -530,7 +530,7 @@ class Node extends \Soosyze\Controller
             $nodeShow = [
                 'key'        => 'node.show',
                 'request'    => self::router()->generateRequest('node.show', [
-                    ':idNode' => $idNode
+                    'idNode' => $idNode
                 ]),
                 'title_link' => t('View')
             ];

--- a/core/modules/Node/Controller/NodeApi.php
+++ b/core/modules/Node/Controller/NodeApi.php
@@ -45,7 +45,7 @@ class NodeApi extends \Soosyze\Controller
 
         $this->container->callHook('node.remove.form.data', [ &$node, $idNode ]);
 
-        $action = self::router()->generateUrl('node.delete', [ ':idNode' => $idNode ]);
+        $action = self::router()->generateUrl('node.delete', [ 'idNode' => $idNode ]);
 
         $form = (new FormNodeDelete([ 'action' => $action, 'method' => 'delete' ], self::router()))
             ->setValues($values)

--- a/core/modules/Node/Controller/NodeClone.php
+++ b/core/modules/Node/Controller/NodeClone.php
@@ -111,7 +111,7 @@ class NodeClone extends \Soosyze\Controller
 
         return new Redirect(
             self::router()->generateUrl('node.edit', [
-                ':idNode' => $this->node[ 'id' ]
+                'idNode' => $this->node[ 'id' ]
             ]),
             302
         );

--- a/core/modules/Node/Controller/NodeManager.php
+++ b/core/modules/Node/Controller/NodeManager.php
@@ -63,7 +63,7 @@ class NodeManager extends \Soosyze\Controller
         return $this->filterPage(1, $req);
     }
 
-    public function filterPage(int $page, ServerRequestInterface $req): Block
+    public function filterPage(int $pageId, ServerRequestInterface $req): Block
     {
         $validator = (new Validator())
             ->setRules([
@@ -116,7 +116,7 @@ class NodeManager extends \Soosyze\Controller
         /* Met en forme les donnes du tableau. */
         $data      = $query->fetchAll();
         $countData = count($data);
-        $nodes     = array_slice($data, self::$limit * ($page - 1), self::$limit);
+        $nodes     = array_slice($data, self::$limit * ($pageId - 1), self::$limit);
         unset($data);
 
         self::nodeuser()->hydrateNodesLinks($nodes);
@@ -167,7 +167,7 @@ class NodeManager extends \Soosyze\Controller
                     'link_type_sort'         => $linkSort->withQuery(http_build_query($paramsTypeSort)),
                     'nodes'                  => $nodes,
                     'order_by'               => $orderBy,
-                    'paginate'               => new Paginator($countData, self::$limit, $page, (string) $linkPagination)
+                    'paginate'               => new Paginator($countData, self::$limit, $pageId, (string) $linkPagination)
         ]);
     }
 

--- a/core/modules/Node/Controller/NodeManager.php
+++ b/core/modules/Node/Controller/NodeManager.php
@@ -55,15 +55,10 @@ class NodeManager extends \Soosyze\Controller
                     'link_search_status'    => self::router()->generateUrl('node.status.search'),
                     'link_search_node_type' => self::router()->generateUrl('node.type.search'),
                 ])
-                ->addBlock('content.table', $this->filterPage(1, $req));
+                ->addBlock('content.table', $this->filter($req));
     }
 
-    public function filter(ServerRequestInterface $req): Block
-    {
-        return $this->filterPage(1, $req);
-    }
-
-    public function filterPage(int $pageId, ServerRequestInterface $req): Block
+    public function filter(ServerRequestInterface $req, int $pageId = 1): Block
     {
         $validator = (new Validator())
             ->setRules([

--- a/core/modules/Node/Form/FormNode.php
+++ b/core/modules/Node/Form/FormNode.php
@@ -350,9 +350,9 @@ class FormNode extends \Soosyze\Components\Form\FormBuilder
                     $form->html("$key-$idEntity-show", '<div class="table-min-width-100"><a:attr>:content</a></div>', [
                             ':content' => $content,
                             'href'     => $this->router->generateUrl('node.entity.edit', [
-                                ':idNode'   => $this->values[ 'id' ],
-                                ':entity'   => $key,
-                                ':idEntity' => $field[ "{$key}_id" ]
+                                'idNode'   => $this->values[ 'id' ],
+                                'entity'   => $key,
+                                'idEntity' => $field[ "{$key}_id" ]
                             ]),
                         ])
                         ->group("$key-$idEntity-actions", 'div', function ($form) use ($field, $idEntity, $key) {
@@ -360,18 +360,18 @@ class FormNode extends \Soosyze\Components\Form\FormBuilder
                                 ':content' => '<i class="fa fa-edit" aria-hidden="true"></i> ' . t('Edit'),
                                 'class'    => 'btn',
                                 'href'     => $this->router->generateUrl('node.entity.edit', [
-                                    ':idNode'   => $this->values[ 'id' ],
-                                    ':entity'   => $key,
-                                    ':idEntity' => $field[ "{$key}_id" ]
+                                    'idNode'   => $this->values[ 'id' ],
+                                    'entity'   => $key,
+                                    'idEntity' => $field[ "{$key}_id" ]
                                 ]),
                             ])
                             ->html("$key-$idEntity-delete", '<a:attr>:content</a>', [
                                 ':content' => '<i class="fa fa-times" aria-hidden="true"></i> ' . t('Delete'),
                                 'class'    => 'btn',
                                 'href'     => $this->router->generateUrl('node.entity.delete', [
-                                    ':idNode'   => $this->values[ 'id' ],
-                                    ':entity'   => $key,
-                                    ':idEntity' => $field[ "{$key}_id" ]
+                                    'idNode'   => $this->values[ 'id' ],
+                                    'entity'   => $key,
+                                    'idEntity' => $field[ "{$key}_id" ]
                                 ]),
                             ]);
                         }, [ 'class' => 'table-width-300' ]);
@@ -385,8 +385,8 @@ class FormNode extends \Soosyze\Components\Form\FormBuilder
                     ':content' => '<i class="fa fa-plus" aria-hidden="true"></i> ' . t('Add content'),
                     'class'    => 'btn btn-primary',
                     'href'     => $this->router->generateUrl('node.entity.create', [
-                        ':idNode' => $this->values[ 'id' ],
-                        ':entity'  => $key,
+                        'idNode' => $this->values[ 'id' ],
+                        'entity'  => $key,
                     ])
                 ]);
             });

--- a/core/modules/Node/Hook/FileManager.php
+++ b/core/modules/Node/Hook/FileManager.php
@@ -67,7 +67,7 @@ class FileManager
         }
 
         $request = $this->router->generateRequest('filemanager.show', [
-            ':path' => "/node/{$content[ 'type' ]}/{$content[ 'id' ]}"
+            'path' => "/node/{$content[ 'type' ]}/{$content[ 'id' ]}"
         ]);
         $this->getFileManager($form, $request);
     }
@@ -79,7 +79,7 @@ class FileManager
         }
 
         $request = $this->router->generateRequest('filemanager.show', [
-            ':path' => "/node/{$node[ 'type' ]}/{$node[ 'id' ]}/$entity"
+            'path' => "/node/{$node[ 'type' ]}/{$node[ 'id' ]}/$entity"
         ]);
         $this->getFileManager($form, $request);
     }

--- a/core/modules/Node/Services/NodeUser.php
+++ b/core/modules/Node/Services/NodeUser.php
@@ -137,7 +137,7 @@ class NodeUser
 
             if ($nodeAdminister || $this->user->isGrantedPermission($nodeEdit)) {
                 $node[ 'link_edit' ] = $this->router->generateUrl('node.edit', [
-                    ':idNode' => $node[ 'id' ]
+                    'idNode' => $node[ 'id' ]
                 ]);
             }
 
@@ -145,7 +145,7 @@ class NodeUser
 
             if ($nodeAdminister || $this->user->isGrantedPermission($nodeClone)) {
                 $node[ 'link_clone' ] = $this->router->generateUrl('node.clone', [
-                    ':idNode' => $node[ 'id' ]
+                    'idNode' => $node[ 'id' ]
                 ]);
             }
 
@@ -153,7 +153,7 @@ class NodeUser
 
             if ($nodeAdminister || $this->user->isGrantedPermission($nodeRemove)) {
                 $node[ 'link_remove' ] = $this->router->generateUrl('node.api.remove', [
-                    ':idNode' => $node[ 'id' ]
+                    'idNode' => $node[ 'id' ]
                 ]);
             }
 
@@ -176,7 +176,7 @@ class NodeUser
 
         if ($this->user->isGranted('user.showed')) {
             $user[ 'link' ] = $this->router->generateUrl('user.show', [
-                ':id' => $node[ 'user_id' ]
+                'id' => $node[ 'user_id' ]
             ]);
         }
 

--- a/core/modules/System/Config/routes-install.php
+++ b/core/modules/System/Config/routes-install.php
@@ -5,7 +5,7 @@ use Soosyze\Components\Router\RouteGroup;
 
 RouteCollection::setNamespace('SoosyzeCore\System\Controller\Install')->name('install.')->prefix('/install')->group(function (RouteGroup $r): void {
     $r->get('index', '/', '@index');
-    $r->get('step', '/step/:id', '@step')->whereWords(':id');
-    $r->post('step.check', '/step/:id', '@stepCheck')->whereWords(':id');
-    $r->post('language', '/language/:id', 'Install@language')->whereWords(':id');
+    $r->get('step', '/step/{id}', '@step')->whereWords('id');
+    $r->post('step.check', '/step/{id}', '@stepCheck')->whereWords('id');
+    $r->post('language', '/language/{id}', 'Install@language')->whereWords('id');
 });

--- a/core/modules/System/Config/routes.php
+++ b/core/modules/System/Config/routes.php
@@ -15,7 +15,7 @@ RouteCollection::setNamespace('SoosyzeCore\System\Controller')->name('system.')-
         $r->get('update', '/update', '@update');
     });
     $r->prefix('/theme')->name('theme.')->setNamespace('\Theme')->group(function (RouteGroup $r): void {
-        $r->get('index', '/', '@index');
+        $r->get('index', '/', '@admin');
         $r->get('admin', '/{type}', '@admin', [ 'type' => 'admin|public' ]);
         $r->get('active', '/{type}/active/{name}', '@active', [
             'type' => 'admin|public', 'name' => '\w+'

--- a/core/modules/System/Config/routes.php
+++ b/core/modules/System/Config/routes.php
@@ -16,12 +16,12 @@ RouteCollection::setNamespace('SoosyzeCore\System\Controller')->name('system.')-
     });
     $r->prefix('/theme')->name('theme.')->setNamespace('\Theme')->group(function (RouteGroup $r): void {
         $r->get('index', '/', '@index');
-        $r->get('admin', '/:type', '@admin', [ ':type' => 'admin|public' ]);
-        $r->get('active', '/:type/active/:name', '@active', [
-            ':type' => 'admin|public', ':name' => '\w+'
+        $r->get('admin', '/{type}', '@admin', [ 'type' => 'admin|public' ]);
+        $r->get('active', '/{type}/active/{name}', '@active', [
+            'type' => 'admin|public', 'name' => '\w+'
         ]);
-        $r->get('edit', '/:type/edit', '@edit', [ ':type' => 'admin|public' ]);
-        $r->post('update', '/:type/edit', '@update', [ ':type' => 'admin|public' ]);
+        $r->get('edit', '/{type}/edit', '@edit', [ 'type' => 'admin|public' ]);
+        $r->post('update', '/{type}/edit', '@update', [ 'type' => 'admin|public' ]);
     });
     $r->prefix('/tool')->name('tool.')->setNamespace('\Tool')->group(function (RouteGroup $r): void {
         $r->get('admin', '/', '@admin');

--- a/core/modules/System/Controller/Install.php
+++ b/core/modules/System/Controller/Install.php
@@ -117,7 +117,7 @@ class Install extends Controller
         /* Validation de l'étape. */
         $this->container->callHook("step.$id.check", [ $id, $req ]);
 
-        $route = self::router()->generateUrl('install.step', [ ':id' => $id ]);
+        $route = self::router()->generateUrl('install.step', [ 'id' => $id ]);
         if (!empty($_SESSION[ 'inputs' ][ $id ]) && empty($_SESSION[ 'messages' ][ $id ])) {
             $this->position($steps, $id);
             if (($next = next($steps)) === false && key($steps) === null) {
@@ -127,7 +127,7 @@ class Install extends Controller
                 return $this->installFinish();
             }
 
-            $route = self::router()->generateUrl('install.step', [ ':id' => $next[ 'key' ] ]);
+            $route = self::router()->generateUrl('install.step', [ 'id' => $next[ 'key' ] ]);
         }
 
         return new Redirect($route, 302);

--- a/core/modules/System/Controller/Theme.php
+++ b/core/modules/System/Controller/Theme.php
@@ -62,8 +62,8 @@ class Theme extends \Soosyze\Controller
 
                 $uriActivate = self::router()
                     ->generateRequest('system.theme.active', [
-                        ':type' => $type,
-                        ':name' => $theme[ 'title' ]
+                        'type' => $type,
+                        'name' => $theme[ 'title' ]
                     ])
                     ->getUri();
 
@@ -83,10 +83,10 @@ class Theme extends \Soosyze\Controller
                 ->make('page.content', 'system/content-themes-admin.php', $this->pathViews, [
                     'active_theme' => $activeTheme,
                     'link_edit'    => self::module()->has('Block')
-                        ? self::router()->generateUrl('block.section.admin', [ ':theme' => $type ])
+                        ? self::router()->generateUrl('block.section.admin', [ 'theme' => $type ])
                         : null,
                     'link_setting' => self::router()->generateUrl('system.theme.edit', [
-                        ':type' => $type
+                        'type' => $type
                     ]),
                     'themes'       => $themes
         ]);
@@ -116,7 +116,7 @@ class Theme extends \Soosyze\Controller
 
             return $this->json(200, [
                     'redirect' => self::router()->generateUrl('system.theme.admin', [
-                        ':type' => $type
+                        'type' => $type
                     ])
             ]);
         }
@@ -133,7 +133,7 @@ class Theme extends \Soosyze\Controller
 
         $attr = [
             'action'  => self::router()->generateUrl('system.theme.update', [
-                ':type' => $type
+                'type' => $type
             ]),
             'class'   => 'form-api',
             'enctype' => 'multipart/form-data',
@@ -156,7 +156,7 @@ class Theme extends \Soosyze\Controller
                 ->make('page.content', 'system/content-form.php', $this->pathViews, [
                     'form'      => $form,
                     'link_edit' => self::router()->generateUrl('system.theme.admin', [
-                        ':type' => $type
+                        'type' => $type
                     ])
                 ]);
     }
@@ -202,7 +202,7 @@ class Theme extends \Soosyze\Controller
             $_SESSION[ 'messages' ][ 'success' ][] = t('Saved configuration');
 
             return $this->json(200, [
-                'redirect' => self::router()->generateUrl('system.theme.admin', [ ':type' => $type ])
+                'redirect' => self::router()->generateUrl('system.theme.admin', [ 'type' => $type ])
             ]);
         }
 
@@ -218,13 +218,13 @@ class Theme extends \Soosyze\Controller
             [
                 'key'        => self::TYPE_PUBLIC,
                 'link'       => self::router()->generateUrl('system.theme.admin', [
-                    ':type' => self::TYPE_PUBLIC
+                    'type' => self::TYPE_PUBLIC
                 ]),
                 'title_link' => t('Public theme')
             ], [
                 'key'        => self::TYPE_ADMIN,
                 'link'       => self::router()->generateUrl('system.theme.admin', [
-                    ':type' => self::TYPE_ADMIN
+                    'type' => self::TYPE_ADMIN
                 ]),
                 'title_link' => t('Admin theme')
             ]

--- a/core/modules/System/Controller/Theme.php
+++ b/core/modules/System/Controller/Theme.php
@@ -30,12 +30,7 @@ class Theme extends \Soosyze\Controller
         $this->pathViews = dirname(__DIR__) . '/Views/';
     }
 
-    public function index(): ResponseInterface
-    {
-        return $this->admin(self::TYPE_PUBLIC);
-    }
-
-    public function admin(string $type): ResponseInterface
+    public function admin(string $type = self::TYPE_PUBLIC): ResponseInterface
     {
         $composers = self::composer()->getThemeComposers();
 

--- a/core/modules/System/Hook/Step.php
+++ b/core/modules/System/Hook/Step.php
@@ -163,7 +163,7 @@ class Step
 
         $profils = $this->getProfils();
         $form    = new FormBuilder([
-            'action' => $this->router->generateUrl('install.step.check', [ ':id' => $id ]),
+            'action' => $this->router->generateUrl('install.step.check', [ 'id' => $id ]),
             'method' => 'post'
         ]);
 
@@ -229,7 +229,7 @@ class Step
         }
 
         $form = (new FormBuilder([
-                'action' => $this->router->generateUrl('install.step.check', [ ':id' => $id ]),
+                'action' => $this->router->generateUrl('install.step.check', [ 'id' => $id ]),
                 'id'     => 'form_lang',
                 'method' => 'post'
                 ])
@@ -302,7 +302,7 @@ class Step
         }
 
         $form = (new FormBuilder([
-            'action' => $this->router->generateUrl('install.step.check', [ ':id' => $id ]),
+            'action' => $this->router->generateUrl('install.step.check', [ 'id' => $id ]),
             'method' => 'post'
             ]))
             ->group('fieldset', 'fieldset', function ($form) use ($values) {

--- a/core/modules/System/Views/install/html-install.php
+++ b/core/modules/System/Views/install/html-install.php
@@ -23,7 +23,7 @@
                         <li class="<?php echo $key === $step_active ? 'step-active' : ''; ?>">
                             <?php ++$i; ?>
                             <?php if ($steps[$step_active]['weight'] > $step['weight']): ?>
-                            <a href="<?php echo $router->generateUrl('install.step', [ ':id' => $key ]); ?>">
+                            <a href="<?php echo $router->generateUrl('install.step', [ 'id' => $key ]); ?>">
                                 <span style="color: #16ab39">✔</span> <?php echo t($step[ 'title' ]); ?>
                             </a>
                             <?php else: ?>

--- a/core/modules/User/Config/routes.php
+++ b/core/modules/User/Config/routes.php
@@ -38,7 +38,7 @@ RouteCollection::setNamespace('SoosyzeCore\User\Controller')->name('user.')->pre
     $r->setNamespace('\UsersManager')->group(function (RouteGroup $r): void {
         $r->get('admin', '/', '@admin');
         $r->get('filter', '/filter', '@filter');
-        $r->get('filter.page', '/filter/{pageId}', '@filterPage', [ 'pageId' => '[1-9]\d*' ]);
+        $r->get('filter.page', '/filter/{pageId}', '@filter', [ 'pageId' => '[1-9]\d*' ]);
     });
     $r->setNamespace('\Permission')->name('permission.')->prefix('/permission')->group(function (RouteGroup $r): void {
         $r->get('admin', '/', '@admin');

--- a/core/modules/User/Config/routes.php
+++ b/core/modules/User/Config/routes.php
@@ -3,33 +3,33 @@
 use Soosyze\Components\Router\RouteCollection;
 use Soosyze\Components\Router\RouteGroup;
 
-define('LOGIN_WITHS', [ ':url' => '(/[\d\w-]{10,})?' ]);
+define('LOGIN_WITHS', [ 'url' => '(/[\d\w-]{10,})?' ]);
 
 RouteCollection::setNamespace('SoosyzeCore\User\Controller\UserApi')->prefix('/api')->group(function (RouteGroup $r): void {
     $r->get('user.api.select', '/user', '@select');
 });
 RouteCollection::setNamespace('SoosyzeCore\User\Controller')->name('user.')->prefix('/user')->group(function (RouteGroup $r): void {
     $r->setNamespace('\Login')->group(function (RouteGroup $r): void {
-        $r->get('login', '/login:url', '@login', LOGIN_WITHS);
-        $r->post('login.check', '/login:url', '@loginCheck', LOGIN_WITHS);
-        $r->get('relogin', '/relogin:url', '@relogin', LOGIN_WITHS);
-        $r->post('relogin.check', '/relogin:url', '@reloginCheck', LOGIN_WITHS);
-        $r->get('reset', '/:id/reset/:token', '@resetUser', [ ':id' => '\d+', ':token' => '[\w-]+' ]);
+        $r->get('login', '/login{url}', '@login', LOGIN_WITHS);
+        $r->post('login.check', '/login{url}', '@loginCheck', LOGIN_WITHS);
+        $r->get('relogin', '/relogin{url}', '@relogin', LOGIN_WITHS);
+        $r->post('relogin.check', '/relogin{url}', '@reloginCheck', LOGIN_WITHS);
+        $r->get('reset', '/{id}/reset/{token}', '@resetUser', [ 'id' => '\d+', 'token' => '[\w-]+' ]);
         $r->get('logout', '/logout', '@logout');
     });
     $r->setNamespace('\Register')->name('register.')->prefix('/register')->group(function (RouteGroup $r): void {
         $r->get('create', '/', '@create');
         $r->post('store', '/', '@store');
-        $r->get('activate', '/:id/activate/:token', '@activate', [ ':id' => '\d+', ':token' => '[\w-]+' ]);
+        $r->get('activate', '/{id}/activate/{token}', '@activate', [ 'id' => '\d+', 'token' => '[\w-]+' ]);
     });
     $r->setNamespace('\User')->group(function (RouteGroup $r): void {
         $r->get('account', '/account', '@account');
-        $r->get('show', '/:id', '@show')->whereDigits(':id');
+        $r->get('show', '/{id}', '@show')->whereDigits('id');
         $r->post('store', '/', '@store');
-        $r->get('edit', '/:id/edit', '@edit')->whereDigits(':id');
-        $r->put('update', '/:id', '@update')->whereDigits(':id');
-        $r->get('remove', '/:id/delete', '@remove')->whereDigits(':id');
-        $r->delete('delete', '/:id', '@delete')->whereDigits(':id');
+        $r->get('edit', '/{id}/edit', '@edit')->whereDigits('id');
+        $r->put('update', '/{id}', '@update')->whereDigits('id');
+        $r->get('remove', '/{id}/delete', '@remove')->whereDigits('id');
+        $r->delete('delete', '/{id}', '@delete')->whereDigits('id');
     });
 });
 RouteCollection::setNamespace('SoosyzeCore\User\Controller')->name('user.')->prefix('/admin/user')->group(function (RouteGroup $r): void {
@@ -38,7 +38,7 @@ RouteCollection::setNamespace('SoosyzeCore\User\Controller')->name('user.')->pre
     $r->setNamespace('\UsersManager')->group(function (RouteGroup $r): void {
         $r->get('admin', '/', '@admin');
         $r->get('filter', '/filter', '@filter');
-        $r->get('filter.page', '/filter/:id', '@filterPage', [ ':id' => '[1-9]\d*' ]);
+        $r->get('filter.page', '/filter/{pageId}', '@filterPage', [ 'pageId' => '[1-9]\d*' ]);
     });
     $r->setNamespace('\Permission')->name('permission.')->prefix('/permission')->group(function (RouteGroup $r): void {
         $r->get('admin', '/', '@admin');
@@ -52,10 +52,10 @@ RouteCollection::setNamespace('SoosyzeCore\User\Controller')->name('user.')->pre
         $r->setNamespace('\Role')->group(function (RouteGroup $r): void {
             $r->get('create', '/create', '@create');
             $r->post('store', '/', '@store');
-            $r->get('edit', '/:id/edit', '@edit')->whereDigits(':id');
-            $r->put('update', '/:id', '@update')->whereDigits(':id');
-            $r->get('remove', '/:id/delete', '@remove')->whereDigits(':id');
-            $r->delete('delete', '/:id', '@delete')->whereDigits(':id');
+            $r->get('edit', '/{id}/edit', '@edit')->whereDigits('id');
+            $r->put('update', '/{id}', '@update')->whereDigits('id');
+            $r->get('remove', '/{id}/delete', '@remove')->whereDigits('id');
+            $r->delete('delete', '/{id}', '@delete')->whereDigits('id');
         });
     });
 });

--- a/core/modules/User/Controller/Login.php
+++ b/core/modules/User/Controller/Login.php
@@ -40,7 +40,7 @@ class Login extends \Soosyze\Controller
         $this->container->callHook('login.form.data', [ &$values ]);
 
         $form = (new FormUser([
-            'action' => self::router()->generateUrl('user.login.check', [ ':url' => $url ]),
+            'action' => self::router()->generateUrl('user.login.check', [ 'url' => $url ]),
             'method' => 'post'
             ], null, self::config()))
             ->setValues($values);
@@ -61,7 +61,7 @@ class Login extends \Soosyze\Controller
                 ->make('page.content', 'user/content-login-login.php', $this->pathViews, [
                     'form'             => $form,
                     'url_relogin'      => self::router()->generateUrl('user.relogin', [
-                        ':url' => $url
+                        'url' => $url
                     ]),
                     'url_register'     => self::router()->generateUrl('user.register.create'),
                     'granted_relogin'  => self::config()->get('settings.user_relogin', Config::USER_RELOGIN),
@@ -134,7 +134,7 @@ class Login extends \Soosyze\Controller
         $values = [];
         $this->container->callHook('relogin.form.data', [ &$values ]);
 
-        $action = self::router()->generateUrl('user.relogin.check', [ ':url' => $url ]);
+        $action = self::router()->generateUrl('user.relogin.check', [ 'url' => $url ]);
 
         $form = (new FormUser([ 'action' => $action, 'method' => 'post' ]))
             ->setValues($values);
@@ -152,7 +152,7 @@ class Login extends \Soosyze\Controller
                 ])
                 ->make('page.content', 'user/content-login-relogin.php', $this->pathViews, [
                     'form'      => $form,
-                    'url_login' => self::router()->generateUrl('user.login', [ ':url' => $url ])
+                    'url_login' => self::router()->generateUrl('user.login', [ 'url' => $url ])
         ]);
     }
 
@@ -190,8 +190,8 @@ class Login extends \Soosyze\Controller
                     ->execute();
 
                 $urlReset = self::router()->generateUrl('user.reset', [
-                    ':id'    => $user[ 'user_id' ],
-                    ':token' => $token
+                    'id'    => $user[ 'user_id' ],
+                    'token' => $token
                 ]);
                 $message  = t('A request for renewal of the password has been made. You can now login by clicking on this link or by copying it to your browser:') . "\n";
                 $message  .= '<a target="_blank" href="' . $urlReset . '" rel="noopener noreferrer" data-auth="NotApplicable">' . $urlReset . '</a>';
@@ -212,7 +212,7 @@ class Login extends \Soosyze\Controller
 
                     return $this->json(200, [
                             'redirect' => self::router()->generateUrl('user.login', [
-                                ':url' => $url
+                                'url' => $url
                             ])
                     ]);
                 }
@@ -258,7 +258,7 @@ class Login extends \Soosyze\Controller
 
         self::auth()->login($user[ 'email' ], $pwd);
 
-        return new Redirect(self::router()->generateUrl('user.edit', [ ':id' => $id ]));
+        return new Redirect(self::router()->generateUrl('user.edit', [ 'id' => $id ]));
     }
 
     private function getRedirectLogin(array $user): string

--- a/core/modules/User/Controller/Register.php
+++ b/core/modules/User/Controller/Register.php
@@ -60,7 +60,7 @@ class Register extends \Soosyze\Controller
                 ->make('page.content', 'user/content-register-create.php', $this->pathViews, [
                     'form'        => $form,
                     'url_relogin' => self::router()->generateUrl('user.login', [
-                        ':url' => $connectUrl
+                        'url' => $connectUrl
                     ])
         ]);
     }
@@ -182,7 +182,7 @@ class Register extends \Soosyze\Controller
 
         $_SESSION[ 'messages' ][ 'success' ][] = t('Your user account has just been activated, you can now login.');
 
-        return new Redirect(self::router()->generateUrl('user.login', [ ':url' => '' ]), 302);
+        return new Redirect(self::router()->generateUrl('user.login', [ 'url' => '' ]), 302);
     }
 
     private function sendMailRegister(string $from): bool
@@ -190,8 +190,8 @@ class Register extends \Soosyze\Controller
         /** @phpstan-var UserEntity $user */
         $user     = self::user()->getUser($from);
         $urlReset = self::router()->generateUrl('user.activate', [
-            ':id'    => $user[ 'user_id' ],
-            ':token' => $user[ 'token_actived' ]
+            'id'    => $user[ 'user_id' ],
+            'token' => $user[ 'token_actived' ]
         ]);
 
         $message = t('A user registration request has been made.') . "<br><br>\n";

--- a/core/modules/User/Controller/Role.php
+++ b/core/modules/User/Controller/Role.php
@@ -91,7 +91,7 @@ class Role extends \Soosyze\Controller
         $this->container->callHook('role.edit.form.data', [ &$values, $id ]);
 
         $form = (new FormUserRole([
-            'action' => self::router()->generateUrl('user.role.update', [ ':id' => $id ]),
+            'action' => self::router()->generateUrl('user.role.update', [ 'id' => $id ]),
             'method' => 'put'
             ]))
             ->setValues($values)
@@ -156,7 +156,7 @@ class Role extends \Soosyze\Controller
         $this->container->callHook('role.remove.form.data', [ &$data, $id ]);
 
         $form = (new FormUserRole([
-            'action' => self::router()->generateUrl('user.role.delete', [ ':id' => $id ]),
+            'action' => self::router()->generateUrl('user.role.delete', [ 'id' => $id ]),
             'method' => 'delete'
             ]))
             ->makeFieldsDelete();
@@ -277,13 +277,13 @@ class Role extends \Soosyze\Controller
             [
                 'key'        => 'user.role.edit',
                 'request'    => self::router()->generateRequest('user.role.edit', [
-                    ':id' => $idRole
+                    'id' => $idRole
                 ]),
                 'title_link' => t('Edit')
             ], [
                 'key'        => 'user.role.remove',
                 'request'    => self::router()->generateRequest('user.role.remove', [
-                    ':id' => $idRole
+                    'id' => $idRole
                 ]),
                 'title_link' => t('Delete')
             ]

--- a/core/modules/User/Controller/RoleManager.php
+++ b/core/modules/User/Controller/RoleManager.php
@@ -38,11 +38,11 @@ class RoleManager extends \Soosyze\Controller
 
         foreach ($values as &$role) {
             $role[ 'link_edit' ] = self::router()->generateUrl('user.role.edit', [
-                ':id' => $role[ 'role_id' ]
+                'id' => $role[ 'role_id' ]
             ]);
             if ($role[ 'role_id' ] > 3) {
                 $role[ 'link_remove' ] = self::router()->generateUrl('user.role.remove', [
-                    ':id' => $role[ 'role_id' ]
+                    'id' => $role[ 'role_id' ]
                 ]);
             }
             $form->group("role_{$role[ 'role_id' ]}-group", 'div', function ($form) use ($role) {

--- a/core/modules/User/Controller/User.php
+++ b/core/modules/User/Controller/User.php
@@ -164,7 +164,7 @@ class User extends \Soosyze\Controller
         $this->container->callHook('user.edit.form.data', [ &$values, $id ]);
 
         $form = (new FormUser([
-            'action'  => self::router()->generateUrl('user.update', [ ':id' => $id ]),
+            'action'  => self::router()->generateUrl('user.update', [ 'id' => $id ]),
             'enctype' => 'multipart/form-data',
             'method'  => 'put' ], self::file(), self::config()))
             ->setValues($values)
@@ -244,7 +244,7 @@ class User extends \Soosyze\Controller
             $_SESSION[ 'messages' ][ 'success' ][] = t('Saved configuration');
 
             return $this->json(200, [
-                    'redirect' => self::router()->generateUrl('user.edit', [ ':id' => $id ])
+                    'redirect' => self::router()->generateUrl('user.edit', [ 'id' => $id ])
             ]);
         }
 
@@ -263,7 +263,7 @@ class User extends \Soosyze\Controller
         $this->container->callHook('user.remove.form.data', [ &$values, $id ]);
 
         $form = (new FormBuilder([
-                'action' => self::router()->generateUrl('user.delete', [ ':id' => $id ]),
+                'action' => self::router()->generateUrl('user.delete', [ 'id' => $id ]),
                 'class' => 'form-api',
                 'method' => 'delete'
                 ]))

--- a/core/modules/User/Controller/UsersManager.php
+++ b/core/modules/User/Controller/UsersManager.php
@@ -76,7 +76,7 @@ class UsersManager extends \Soosyze\Controller
     /**
      * @return Block|ResponseInterface
      */
-    public function filterPage(int $page, ServerRequestInterface $req)
+    public function filterPage(int $pageId, ServerRequestInterface $req)
     {
         if (!$this->isAdmin) {
             return $this->get404($req);
@@ -131,7 +131,7 @@ class UsersManager extends \Soosyze\Controller
         $data = self::query()->fetchAll();
 
         $countData = count($data);
-        $users     = array_slice($data, self::$limit * ($page - 1), self::$limit);
+        $users     = array_slice($data, self::$limit * ($pageId - 1), self::$limit);
 
         $this->hydrateUsersLinks($users);
 
@@ -179,7 +179,7 @@ class UsersManager extends \Soosyze\Controller
                     'link_time_access_sort'    => $linkSort->withQuery(http_build_query($paramsTimeAccessSort)),
                     'link_time_installed_sort' => $linkSort->withQuery(http_build_query($paramsTimeInstalledSort)),
                     'order_by'                 => $orderBy,
-                    'paginate'                 => new Paginator($countData, self::$limit, $page, (string) $linkPagination),
+                    'paginate'                 => new Paginator($countData, self::$limit, $pageId, (string) $linkPagination),
                     'users'                    => $users
         ]);
     }
@@ -205,13 +205,13 @@ class UsersManager extends \Soosyze\Controller
     {
         foreach ($users as &$user) {
             $user[ 'link_show' ]   = self::router()->generateUrl('user.show', [
-                ':id' => $user[ 'user_id' ]
+                'id' => $user[ 'user_id' ]
             ]);
             $user[ 'link_edit' ]   = self::router()->generateUrl('user.edit', [
-                ':id' => $user[ 'user_id' ]
+                'id' => $user[ 'user_id' ]
             ]);
             $user[ 'link_remove' ] = self::router()->generateUrl('user.remove', [
-                ':id' => $user[ 'user_id' ]
+                'id' => $user[ 'user_id' ]
             ]);
             $user[ 'roles' ]       = self::user()->getRolesUser($user[ 'user_id' ]);
             $user[ 'username' ]    = Util::strHighlight($this->username, $user[ 'username' ]);

--- a/core/modules/User/Controller/UsersManager.php
+++ b/core/modules/User/Controller/UsersManager.php
@@ -45,7 +45,7 @@ class UsersManager extends \Soosyze\Controller
     {
         $this->isAdmin = true;
 
-        $block = $this->filterPage(1, $req);
+        $block = $this->filter($req);
         if ($block instanceof ResponseInterface) {
             return $block;
         }
@@ -68,15 +68,7 @@ class UsersManager extends \Soosyze\Controller
     /**
      * @return Block|ResponseInterface
      */
-    public function filter(ServerRequestInterface $req)
-    {
-        return $this->filterPage(1, $req);
-    }
-
-    /**
-     * @return Block|ResponseInterface
-     */
-    public function filterPage(int $pageId, ServerRequestInterface $req)
+    public function filter(ServerRequestInterface $req, int $pageId = 1)
     {
         if (!$this->isAdmin) {
             return $this->get404($req);

--- a/core/modules/User/Hook/ApiRoute.php
+++ b/core/modules/User/Hook/ApiRoute.php
@@ -36,19 +36,19 @@ class ApiRoute implements \SoosyzeCore\System\ApiRouteInterface
                 'title' => t('My account')
             ], [
                 'link'  => $this->router->generateUrl('user.login', [
-                    ':url' => $this->connectUrl
+                    'url' => $this->connectUrl
                 ]),
                 'route' => 'user/login',
                 'title' => t('Sign in')
             ], [
                 'link'  => $this->router->generateUrl('user.relogin', [
-                    ':url' => $this->connectUrl
+                    'url' => $this->connectUrl
                 ]),
                 'route' => 'user/relogin',
                 'title' => t('Request a new password')
             ], [
                 'link'  => $this->router->generateUrl('user.logout', [
-                    ':url' => $this->connectUrl
+                    'url' => $this->connectUrl
                 ]),
                 'route' => 'user/logout',
                 'title' => t('Sign out')

--- a/core/modules/User/Hook/Block.php
+++ b/core/modules/User/Hook/Block.php
@@ -60,7 +60,7 @@ class Block implements \SoosyzeCore\Block\BlockInterface
         }
 
         $form = (new FormUser([
-                'action' => $this->router->generateUrl('user.login.check', [ ':url' => '' ]),
+                'action' => $this->router->generateUrl('user.login.check', [ 'url' => '' ]),
                 'method' => 'post'
                 ], null, $this->config));
 
@@ -76,7 +76,7 @@ class Block implements \SoosyzeCore\Block\BlockInterface
                 'granted_register' => $this->config->get('settings.user_register', HookConfig::USER_REGISTER),
                 'granted_relogin'  => $this->config->get('settings.user_relogin', HookConfig::USER_RELOGIN),
                 'url_relogin'      => $this->router->generateUrl('user.relogin', [
-                    ':url' => ''
+                    'url' => ''
                 ]),
                 'url_register'     => $this->router->generateUrl('user.register.create')
         ]);

--- a/core/modules/User/Hook/Config.php
+++ b/core/modules/User/Hook/Config.php
@@ -99,7 +99,7 @@ final class Config implements \SoosyzeCore\Config\ConfigInterface
                         'data-tooltip' => t('If the site is managed by a restricted team, you can choose a suffix for the URL to better protect your login form.')
                         . ' ' . t('Example: :value ', [
                             ':value' => $this->router->generateUrl('user.login', [
-                                ':url' => '/Ab1P-9eM_s8Y'
+                                'url' => '/Ab1P-9eM_s8Y'
                             ])
                         ]),
                         'for'          => 'connect_url'
@@ -107,7 +107,7 @@ final class Config implements \SoosyzeCore\Config\ConfigInterface
                     ->group('connect_url-flex', 'div', function ($form) use ($data) {
                         $form->html('base_path', '<span:attr>:content</span>', [
                             ':content' => $this->router->generateUrl('user.login', [
-                                ':url' => ''
+                                'url' => ''
                             ])
                         ])
                         ->text('connect_url', [

--- a/core/modules/User/Services/User.php
+++ b/core/modules/User/Services/User.php
@@ -176,19 +176,19 @@ class User
             [
                 'key'        => 'user.show',
                 'request'    => $this->router->generateRequest('user.show', [
-                    ':id' => $id
+                    'id' => $id
                 ]),
                 'title_link' => t('View')
             ], [
                 'key'        => 'user.edit',
                 'request'    => $this->router->generateRequest('user.edit', [
-                    ':id' => $id
+                    'id' => $id
                 ]),
                 'title_link' => t('Edit')
             ], [
                 'key'        => 'user.remove',
                 'request'    => $this->router->generateRequest('user.remove', [
-                    ':id' => $id
+                    'id' => $id
                 ]),
                 'title_link' => t('Delete')
             ]


### PR DESCRIPTION
Les paramètres dynamiques des routes doivent être entourées d'accolades pour éviter les collisions de paramètres.
Les accolades ne sont plus nécessaires dans les paramètres de génération de route.
Les valeurs par défauts sont ajoutées à la méthode appelée.