### PR TITLE
chore: standardized hook calls

### DIFF
--- a/core/modules/Block/Controller/Section.php
+++ b/core/modules/Block/Controller/Section.php
@@ -65,14 +65,28 @@ class Section extends \Soosyze\Controller
             ])
             ->setInputs((array) $req->getParsedBody());
 
+        $this->container->callHook('block.section.update.validator', [
+            &$validator, $id
+        ]);
+
         if ($validator->isValid()) {
+            $data = [
+                'weight'  => $validator->getInputInt('weight'),
+                'section' => $validator->getInputString('section')
+            ];
+
+            $this->container->callHook('block.section.update.before', [
+                $validator, &$data, $id
+            ]);
+
             self::query()
-                ->update('block', [
-                    'weight'  => $validator->getInputInt('weight'),
-                    'section' => $validator->getInputString('section')
-                ])
+                ->update('block', $data)
                 ->where('block_id', '=', $id)
                 ->execute();
+
+            $this->container->callHook('block.section.update.after', [
+                $validator, $data, $id
+            ]);
         }
 
         return $this->json(200);

--- a/core/modules/FileManager/Controller/FilePermission.php
+++ b/core/modules/FileManager/Controller/FilePermission.php
@@ -230,9 +230,11 @@ class FilePermission extends \Soosyze\Controller
                     'messages' => [ 'errors' => [ t('The requested resource does not exist.') ] ]
             ]);
         }
+
         $validator = (new Validator())
             ->addRule('token_file_permission', 'token')
             ->setInputs((array) $req->getParsedBody());
+
         $this->container->callHook('filemanager.permission.delete.validator', [
             &$validator, $id
         ]);

--- a/core/modules/FileManager/Controller/FilePermissionManager.php
+++ b/core/modules/FileManager/Controller/FilePermissionManager.php
@@ -103,7 +103,7 @@ class FilePermissionManager extends \Soosyze\Controller
                 ];
 
                 $this->container->callHook('filemanager.permission.admin.check.before', [
-                    &$validator, &$data
+                    $validator, &$data
                 ]);
 
                 self::query()

--- a/core/modules/Menu/Controller/Menu.php
+++ b/core/modules/Menu/Controller/Menu.php
@@ -91,7 +91,7 @@ class Menu extends \Soosyze\Controller
             return $this->get404($req);
         }
 
-        $this->container->callHook('menu.store.form.data', [ &$values ]);
+        $this->container->callHook('menu.store.form.data', [ &$values, $menuId ]);
 
         $action = self::router()->generateUrl('menu.update', [ 'menuId' => $menuId ]);
 
@@ -99,7 +99,7 @@ class Menu extends \Soosyze\Controller
             ->setValues($values)
             ->makeFields();
 
-        $this->container->callHook('menu.store.form', [ &$form, $values ]);
+        $this->container->callHook('menu.store.form', [ &$form, $values, $menuId ]);
 
         return self::template()
                 ->getTheme('theme_admin')
@@ -125,17 +125,17 @@ class Menu extends \Soosyze\Controller
 
         $validator = $this->getValidator($req);
 
-        $this->container->callHook('menu.update.validator', [ &$validator ]);
+        $this->container->callHook('menu.update.validator', [ &$validator, $menuId ]);
 
         if ($validator->isValid()) {
             $data = $this->getData($validator);
 
-            $this->container->callHook('menu.update.before', [ $validator, &$data ]);
+            $this->container->callHook('menu.update.before', [ $validator, &$data, $menuId ]);
             self::query()
                 ->update('menu', $data)
                 ->where('menu_id', '=', $menuId)
                 ->execute();
-            $this->container->callHook('menu.update.after', [ $validator ]);
+            $this->container->callHook('menu.update.after', [ $validator, $data, $menuId ]);
 
             $_SESSION[ 'messages' ][ 'success' ][] = t('Saved configuration');
 
@@ -207,10 +207,8 @@ class Menu extends \Soosyze\Controller
         }
 
         $validator = (new Validator())
-            ->setRules([
-                'menu_id' => 'required|int',
-            ])
-            ->setInputs([ 'menu_id' => $menuId ]);
+            ->addRule('token_menu_remove', 'token')
+            ->setInputs((array) $req->getParsedBody());
 
         $this->container->callHook('menu.delete.validator', [ &$validator, $menuId ]);
 

--- a/core/modules/Node/Hook/Menu.php
+++ b/core/modules/Node/Hook/Menu.php
@@ -290,10 +290,10 @@ class Menu
             ->execute();
     }
 
-    public function hookLinkDeleteValid(Validator $validator, int $id): void
+    public function hookLinkDeleteValid(Validator $validator, int $menuId, int $linkId): void
     {
         $this->query->from('node_menu_link')
-            ->where('menu_link_id', '=', $id)
+            ->where('menu_link_id', '=', $linkId)
             ->delete()
             ->execute();
     }

--- a/core/modules/User/Controller/Login.php
+++ b/core/modules/User/Controller/Login.php
@@ -37,7 +37,7 @@ class Login extends \Soosyze\Controller
         }
 
         $values = [];
-        $this->container->callHook('login.form.data', [ &$values ]);
+        $this->container->callHook('user.login.form.data', [ &$values ]);
 
         $form = (new FormUser([
             'action' => self::router()->generateUrl('user.login.check', [ 'url' => $url ]),
@@ -51,7 +51,7 @@ class Login extends \Soosyze\Controller
                 ->passwordCurrentGroup($formbuilder);
         })->submitForm(t('Sign in'));
 
-        $this->container->callHook('login.form', [ &$form, $values ]);
+        $this->container->callHook('user.login.form', [ &$form, $values ]);
 
         return self::template()
                 ->view('page', [
@@ -84,6 +84,8 @@ class Login extends \Soosyze\Controller
                 'token_user_form' => 'token'
             ])
             ->setInputs((array) $req->getParsedBody());
+
+        $this->container->callHook('user.login.check.validator', [ &$validator, $url ]);
 
         if (!$validator->isValid()) {
             return $this->json(400, [
@@ -132,7 +134,7 @@ class Login extends \Soosyze\Controller
         }
 
         $values = [];
-        $this->container->callHook('relogin.form.data', [ &$values ]);
+        $this->container->callHook('user.relogin.form.data', [ &$values, $url ]);
 
         $action = self::router()->generateUrl('user.relogin.check', [ 'url' => $url ]);
 
@@ -143,7 +145,7 @@ class Login extends \Soosyze\Controller
             $form->emailGroup($formBuilder);
         })->submitForm();
 
-        $this->container->callHook('relogin.form', [ &$form, $values ]);
+        $this->container->callHook('user.relogin.form', [ &$form, $values, $url ]);
 
         return self::template()
                 ->view('page', [
@@ -170,6 +172,8 @@ class Login extends \Soosyze\Controller
                 'token_user_form' => 'required|token'
             ])
             ->setInputs((array) $req->getParsedBody());
+
+        $this->container->callHook('user.relogin.check.validator', [ &$validator, $url ]);
 
         if ($validator->isValid()) {
             $user = self::user()->getUserActived($validator->getInputString('email'));

--- a/core/modules/User/Controller/Role.php
+++ b/core/modules/User/Controller/Role.php
@@ -34,7 +34,7 @@ class Role extends \Soosyze\Controller
     public function create(ServerRequestInterface $req): ResponseInterface
     {
         $values = [];
-        $this->container->callHook('role.create.form.data', [ &$values ]);
+        $this->container->callHook('user.role.create.form.data', [ &$values ]);
 
         $form = (new FormUserRole([
             'action' => self::router()->generateUrl('user.role.store'),
@@ -43,7 +43,7 @@ class Role extends \Soosyze\Controller
             ->setValues($values)
             ->makeFields();
 
-        $this->container->callHook('role.create.form', [ &$form, $values ]);
+        $this->container->callHook('user.role.create.form', [ &$form, $values ]);
 
         return self::template()
                 ->getTheme('theme_admin')
@@ -60,14 +60,14 @@ class Role extends \Soosyze\Controller
     {
         $validator = $this->getValidator($req);
 
-        $this->container->callHook('role.store.validator', [ &$validator ]);
+        $this->container->callHook('user.role.store.validator', [ &$validator ]);
 
         if ($validator->isValid()) {
             $data = $this->getData($validator);
 
-            $this->container->callHook('role.store.before', [ &$validator, &$data ]);
+            $this->container->callHook('user.role.store.before', [ $validator, &$data ]);
             self::query()->insertInto('role', array_keys($data))->values($data)->execute();
-            $this->container->callHook('role.store.after', [ $validator ]);
+            $this->container->callHook('user.role.store.after', [ $validator, $data ]);
 
             $_SESSION[ 'messages' ][ 'success' ][] = t('Saved configuration');
 
@@ -88,7 +88,7 @@ class Role extends \Soosyze\Controller
             return $this->get404($req);
         }
 
-        $this->container->callHook('role.edit.form.data', [ &$values, $id ]);
+        $this->container->callHook('user.role.edit.form.data', [ &$values, $id ]);
 
         $form = (new FormUserRole([
             'action' => self::router()->generateUrl('user.role.update', [ 'id' => $id ]),
@@ -97,7 +97,7 @@ class Role extends \Soosyze\Controller
             ->setValues($values)
             ->makeFields();
 
-        $this->container->callHook('role.edit.form', [ &$form, $values, $id ]);
+        $this->container->callHook('user.role.edit.form', [ &$form, $values, $id ]);
 
         return self::template()
                 ->getTheme('theme_admin')
@@ -121,16 +121,16 @@ class Role extends \Soosyze\Controller
 
         $validator = $this->getValidator($req);
 
-        $this->container->callHook('role.update.validator', [ &$validator ]);
+        $this->container->callHook('user.role.update.validator', [ &$validator, $id ]);
 
         if ($validator->isValid()) {
             $data = $this->getData($validator);
 
-            $this->container->callHook('role.udpate.before', [
-                &$validator, &$data, $id
+            $this->container->callHook('user.role.udpate.before', [
+                $validator, &$data, $id
             ]);
             self::query()->update('role', $data)->where('role_id', '=', $id)->execute();
-            $this->container->callHook('role.udpate.after', [
+            $this->container->callHook('user.role.udpate.after', [
                 $validator, $data, $id
             ]);
 
@@ -149,11 +149,11 @@ class Role extends \Soosyze\Controller
 
     public function remove(int $id, ServerRequestInterface $req): ResponseInterface
     {
-        if (!($data = $this->find($id))) {
+        if (!($values = $this->find($id))) {
             return $this->get404($req);
         }
 
-        $this->container->callHook('role.remove.form.data', [ &$data, $id ]);
+        $this->container->callHook('user.role.remove.form.data', [ &$values, $id ]);
 
         $form = (new FormUserRole([
             'action' => self::router()->generateUrl('user.role.delete', [ 'id' => $id ]),
@@ -161,13 +161,13 @@ class Role extends \Soosyze\Controller
             ]))
             ->makeFieldsDelete();
 
-        $this->container->callHook('role.remove.form', [ &$form, $data, $id ]);
+        $this->container->callHook('user.role.remove.form', [ &$form, $values, $id ]);
 
         return self::template()
                 ->getTheme('theme_admin')
                 ->view('page', [
                     'icon'       => '<i class="fa fa-user-tag" aria-hidden="true"></i>',
-                    'title_main' => t('Remove :name role', [ ':name' => $data[ 'role_label' ] ])
+                    'title_main' => t('Remove :name role', [ ':name' => $values[ 'role_label' ] ])
                 ])
                 ->view('page.submenu', $this->getRoleSubmenu('user.role.remove', $id))
                 ->make('page.content', 'user/content-role-form.php', $this->pathViews, [
@@ -191,10 +191,10 @@ class Role extends \Soosyze\Controller
             ->setInputs((array) $req->getParsedBody())
             ->addInput('id', $id);
 
-        $this->container->callHook('role.delete.validator', [ &$validator, $id ]);
+        $this->container->callHook('user.role.delete.validator', [ &$validator, $id ]);
 
         if ($validator->isValid()) {
-            $this->container->callHook('role.delete.before', [ $validator, $id ]);
+            $this->container->callHook('user.role.delete.before', [ $validator, $id ]);
 
             self::query()->from('user_role')
                 ->where('role_id', '=', $id)
@@ -211,7 +211,7 @@ class Role extends \Soosyze\Controller
                 ->delete()
                 ->execute();
 
-            $this->container->callHook('role.delete.after', [ $validator, $id ]);
+            $this->container->callHook('user.role.delete.after', [ $validator, $id ]);
 
             $_SESSION[ 'messages' ][ 'success' ][] = t('Saved configuration');
 

--- a/core/modules/User/Controller/RoleManager.php
+++ b/core/modules/User/Controller/RoleManager.php
@@ -105,7 +105,7 @@ class RoleManager extends \Soosyze\Controller
                 ];
 
                 $this->container->callHook('user.role.admin.check.before', [
-                    &$validator, &$data
+                    $validator, &$data
                 ]);
 
                 self::query()
@@ -113,7 +113,9 @@ class RoleManager extends \Soosyze\Controller
                     ->where('role_id', '=', $role[ 'role_id' ])
                     ->execute();
 
-                $this->container->callHook('user.role.admin.check.after', [ &$validator ]);
+                $this->container->callHook('user.role.admin.check.after', [
+                    $validator, $data
+                ]);
             }
 
             $_SESSION[ 'messages' ][ 'success' ][] = t('Saved configuration');

--- a/core/modules/User/Controller/User.php
+++ b/core/modules/User/Controller/User.php
@@ -122,7 +122,7 @@ class User extends \Soosyze\Controller
         if ($validator->isValid() && $validatorRoles->isValid()) {
             $data = $this->getData($validator);
 
-            $this->container->callHook('user.store.before', [ &$validator, &$data ]);
+            $this->container->callHook('user.store.before', [ $validator, &$data ]);
             self::query()->insertInto('user', array_keys($data))
                 ->values($data)
                 ->execute();
@@ -140,7 +140,7 @@ class User extends \Soosyze\Controller
             self::query()->execute();
 
             $this->savePicture($user[ 'user_id' ], $validator);
-            $this->container->callHook('user.store.after', [ &$validator ]);
+            $this->container->callHook('user.store.after', [ $validator, $data ]);
 
             $_SESSION[ 'messages' ][ 'success' ][] = t('Saved configuration');
 
@@ -225,14 +225,14 @@ class User extends \Soosyze\Controller
             $data = $this->getData($validator, $id);
 
             $this->container->callHook('user.update.before', [
-                &$validator, &$data, $id
+                $validator, &$data, $id
             ]);
             self::query()->update('user', $data)->where('user_id', '=', $id)->execute();
 
             $this->updateRole($validator, $id);
 
             $this->savePicture($id, $validator);
-            $this->container->callHook('user.update.after', [ &$validator, $id ]);
+            $this->container->callHook('user.update.after', [ &$validator, $data, $id ]);
 
             if (($userCurrent = self::user()->isConnected()) && $userCurrent[ 'user_id' ] == $id) {
                 $pwd = empty($data[ 'password' ])


### PR DESCRIPTION
Mise en place de la structure de hook suivante:
```
callHook('{module.controller}.create.form.data', [ &$values, ...$param ]);
callHook('{module.controller}.create.form', [ &$form, $values, ...$param ]);

callHook('{module.controller}.store.validator', [ &$validator, ...$param ]);
callHook('{module.controller}.store.before', [ $validator, &$data, ...$param ]);
callHook('{module.controller}.store.after', [ $validator, $data, ...$param ]);

callHook('{module.controller}.edit.form.data', [ &$values, ...$param ]);
callHook('{module.controller}.edit.form', [ &$form, $values, ...$param ]);

callHook('{module.controller}.update.validator', [ &$validator, ...$param ]);
callHook('{module.controller}.update.before', [ $validator, &$data, ...$param ]);
callHook('{module.controller}.update.after', [ $validator, $data, ...$param ]);

callHook('{module.controller}.remove.form.data', [ &$values, ...$param ]);
callHook('{module.controller}.remove.form', [ &$form, $values, ...$param ]);

callHook('{module.controller}.delete.validator', [ &$validator, ...$param ]);
callHook('{module.controller}.delete.before', [ $validator, ...$param ]);
callHook('{module.controller}.delete.after', [ $validator, ...$param ]);
```